### PR TITLE
Nomenclature typo corrected

### DIFF
--- a/BaseOAuth.php
+++ b/BaseOAuth.php
@@ -13,7 +13,7 @@ use Yii;
 use yii\helpers\Json;
 
 /**
- * BaseClient is a base class for the OAuth clients.
+ * BaseOAuth is a base class for the OAuth clients.
  *
  * @see http://oauth.net/
  *


### PR DESCRIPTION
Small Typo in PHP Doc: Should be `BaseOAuth` instead of `BaseClient`.
