### PR TITLE
Added initUserParameters and initUserHeaders for customizing api call…

### DIFF
--- a/BaseOAuth.php
+++ b/BaseOAuth.php
@@ -50,6 +50,14 @@ abstract class BaseOAuth extends BaseClient implements ClientInterface
      * @var string auth request scope.
      */
     public $scope;
+    /**
+     * @var array parameters for initializing authenticated user attributes.
+     */
+    public $initUserParameters = [];
+    /**
+     * @var array headers for initializing authenticated user attributes.
+     */
+    public $initUserHeaders = [];
 
     /**
      * @var string URL, which user will be redirected after authentication at the OAuth provider web site.

--- a/clients/Facebook.php
+++ b/clients/Facebook.php
@@ -63,7 +63,7 @@ class Facebook extends OAuth2
      */
     protected function initUserAttributes()
     {
-        return $this->api('me', 'GET');
+        return $this->api('me', 'GET', $this->initUserParameters);
     }
 
     /**

--- a/clients/Twitter.php
+++ b/clients/Twitter.php
@@ -64,14 +64,24 @@ class Twitter extends OAuth1
      * @inheritdoc
      */
     public $apiBaseUrl = 'https://api.twitter.com/1.1';
-
+    /**
+     * @var array list of query parameters, which should be requested from API to initialize user attributes.
+     * @since 2.0.4
+     */
+    public $queryParameters = [
+        'id',
+        'email-address',
+        'first-name',
+        'last-name',
+        'public-profile-url',
+    ];
 
     /**
      * @inheritdoc
      */
     protected function initUserAttributes()
     {
-        return $this->api('account/verify_credentials.json', 'GET');
+        return $this->api('account/verify_credentials.json', 'GET', $this->initUserParameters);
     }
 
     /**


### PR DESCRIPTION
… on initUserAttributes. Added initUserParameters to Facebook and Twitter clients.
So we can add to the configuration:
``` PHP
'authClientCollection' => [
            'class' => 'yii\authclient\Collection',
            'clients' => [
                'facebook' => [
                    'class' => 'yii\authclient\clients\Facebook',
                    'clientId' => 'CLIENTID',
                    'clientSecret' => 'CLIENTSECRET',
                    'authUrl' => 'https://www.facebook.com/dialog/oauth?display=popup',
                    'scope' => 'email,user_location,user_friends,publish_actions',
                    'initUserParameters' => ['fields'=>'id,first_name,last_name,name,location,picture{url}']
                ],
                'twitter' => [
                    'class' => 'yii\authclient\clients\Twitter',
                    'consumerKey' => 'CONSUMERKEY',
                    'consumerSecret' => 'CONSUMERSECRET',
                    'initUserParameters' => ['include_entities'=> false, 'skip_status'=>true, 'include_email'=>true]
                ]
            ],
```
I changed only clients of Facebook and Twitter, because these are what I needI changed only clients of Facebook and Twitter, because these are what I use and I have no knowledge about the other clients.