### PR TITLE
Allow params to be array or string.  Allow curl Files.  Solves several issues. 

### DIFF
--- a/BaseOAuth.php
+++ b/BaseOAuth.php
@@ -168,12 +168,12 @@ abstract class BaseOAuth extends BaseClient implements ClientInterface
      * Sends HTTP request.
      * @param string $method request type.
      * @param string $url request URL.
-     * @param array $params request params.
+     * @param mixed $params request params.
      * @param array $headers additional request headers.
      * @return array response.
      * @throws Exception on failure.
      */
-    protected function sendRequest($method, $url, array $params = [], array $headers = [])
+    protected function sendRequest($method, $url, $params = [], array $headers = [])
     {
         $curlOptions = $this->mergeCurlOptions(
             $this->defaultCurlOptions(),
@@ -499,12 +499,12 @@ abstract class BaseOAuth extends BaseClient implements ClientInterface
      * Performs request to the OAuth API.
      * @param string $apiSubUrl API sub URL, which will be append to [[apiBaseUrl]], or absolute API URL.
      * @param string $method request method.
-     * @param array $params request parameters.
+     * @param mixed $params request parameters.
      * @param array $headers additional request headers.
      * @return array API response
      * @throws Exception on failure.
      */
-    public function api($apiSubUrl, $method = 'GET', array $params = [], array $headers = [])
+    public function api($apiSubUrl, $method = 'GET', $params = [], array $headers = [])
     {
         if (preg_match('/^https?:\\/\\//is', $apiSubUrl)) {
             $url = $apiSubUrl;
@@ -526,7 +526,7 @@ abstract class BaseOAuth extends BaseClient implements ClientInterface
      * @return array CUrl options.
      * @throws Exception on failure.
      */
-    abstract protected function composeRequestCurlOptions($method, $url, array $params);
+    abstract protected function composeRequestCurlOptions($method, $url, $params);
 
     /**
      * Gets new auth token to replace expired one.
@@ -540,10 +540,10 @@ abstract class BaseOAuth extends BaseClient implements ClientInterface
      * @param OAuthToken $accessToken actual access token.
      * @param string $url absolute API URL.
      * @param string $method request method.
-     * @param array $params request parameters.
+     * @param mixed $params request parameters.
      * @param array $headers additional request headers.
      * @return array API response.
      * @throws Exception on failure.
      */
-    abstract protected function apiInternal($accessToken, $url, $method, array $params, array $headers);
+    abstract protected function apiInternal($accessToken, $url, $method, $params, array $headers);
 }

--- a/BaseOAuth.php
+++ b/BaseOAuth.php
@@ -249,6 +249,23 @@ abstract class BaseOAuth extends BaseClient implements ClientInterface
     }
 
     /**
+     * Detect if the params have a file to upload.
+     *
+     * @param array $params
+     *
+     * @return boolean
+     */
+    protected function paramsHaveFile(array $params)
+    {
+    	foreach ($params as $value) {
+    		if ($value instanceof \CURLFile) {
+    			return true;
+    		}
+    	}
+    	return false;
+    }
+
+    /**
      * Processes raw response converting it to actual data.
      * @param string $rawResponse raw response.
      * @param string $contentType response content type.

--- a/OAuth1.php
+++ b/OAuth1.php
@@ -167,11 +167,11 @@ class OAuth1 extends BaseOAuth
      * Composes HTTP request CUrl options, which will be merged with the default ones.
      * @param string $method request type.
      * @param string $url request URL.
-     * @param array $params request params.
+     * @param mixed $params request params.
      * @return array CUrl options.
      * @throws Exception on failure.
      */
-    protected function composeRequestCurlOptions($method, $url, array $params)
+    protected function composeRequestCurlOptions($method, $url, $params)
     {
         $curlOptions = [];
         switch ($method) {
@@ -182,7 +182,7 @@ class OAuth1 extends BaseOAuth
             case 'POST': {
                 $curlOptions[CURLOPT_POST] = true;
                 if (!empty($params)) {
-                    $curlOptions[CURLOPT_POSTFIELDS] = !$this->paramsHaveFile($params) ? http_build_query($params, null, '&', PHP_QUERY_RFC3986) : $params;
+                    $curlOptions[CURLOPT_POSTFIELDS] = !parent::paramsHaveFile($params) ? (is_array($params) || is_object($params)) ? http_build_query($params, null, '&', PHP_QUERY_RFC3986) : $params : $params;
                 }
                 $authorizationHeader = $this->composeAuthorizationHeader($params);
                 if (!empty($authorizationHeader)) {
@@ -211,7 +211,7 @@ class OAuth1 extends BaseOAuth
     /**
      * @inheritdoc
      */
-    protected function apiInternal($accessToken, $url, $method, array $params, array $headers)
+    protected function apiInternal($accessToken, $url, $method, $params, array $headers)
     {
         $params['oauth_consumer_key'] = $this->consumerKey;
         $params['oauth_token'] = $accessToken->getToken();

--- a/OAuth1.php
+++ b/OAuth1.php
@@ -182,7 +182,7 @@ class OAuth1 extends BaseOAuth
             case 'POST': {
                 $curlOptions[CURLOPT_POST] = true;
                 if (!empty($params)) {
-                    $curlOptions[CURLOPT_POSTFIELDS] = !parent::paramsHaveFile($params) ? (is_array($params) || is_object($params)) ? http_build_query($params, null, '&', PHP_QUERY_RFC3986) : $params : $params;
+                    $curlOptions[CURLOPT_POSTFIELDS] = (is_array($params)) ? !parent::paramsHaveFile($params) ? http_build_query($params, null, '&', PHP_QUERY_RFC3986) : $params : $params;
                 }
                 $authorizationHeader = $this->composeAuthorizationHeader($params);
                 if (!empty($authorizationHeader)) {

--- a/OAuth1.php
+++ b/OAuth1.php
@@ -181,9 +181,8 @@ class OAuth1 extends BaseOAuth
             }
             case 'POST': {
                 $curlOptions[CURLOPT_POST] = true;
-                $curlOptions[CURLOPT_HTTPHEADER] = ['Content-type: application/x-www-form-urlencoded'];
                 if (!empty($params)) {
-                    $curlOptions[CURLOPT_POSTFIELDS] = http_build_query($params, '', '&', PHP_QUERY_RFC3986);
+                    $curlOptions[CURLOPT_POSTFIELDS] = !$this->paramsHaveFile($params) ? http_build_query($params, null, '&', PHP_QUERY_RFC3986) : $params;
                 }
                 $authorizationHeader = $this->composeAuthorizationHeader($params);
                 if (!empty($authorizationHeader)) {

--- a/OAuth2.php
+++ b/OAuth2.php
@@ -111,7 +111,7 @@ class OAuth2 extends BaseOAuth
             }
             case 'POST': {
                 $curlOptions[CURLOPT_POST] = true;
-                $curlOptions[CURLOPT_POSTFIELDS] = !parent::paramsHaveFile($params) ? (is_array($params) || is_object($params)) ? http_build_query($params, null, '&', PHP_QUERY_RFC3986) : $params : $params;
+                $curlOptions[CURLOPT_POSTFIELDS] = (is_array($params)) ? !parent::paramsHaveFile($params) ? http_build_query($params, null, '&', PHP_QUERY_RFC3986) : $params : $params;
                 break;
             }
             case 'HEAD': {

--- a/OAuth2.php
+++ b/OAuth2.php
@@ -111,8 +111,7 @@ class OAuth2 extends BaseOAuth
             }
             case 'POST': {
                 $curlOptions[CURLOPT_POST] = true;
-                $curlOptions[CURLOPT_HTTPHEADER] = ['Content-type: application/x-www-form-urlencoded'];
-                $curlOptions[CURLOPT_POSTFIELDS] = http_build_query($params, '', '&', PHP_QUERY_RFC3986);
+                $curlOptions[CURLOPT_POSTFIELDS] = !$this->paramsHaveFile($params) ? http_build_query($params, null, '&', PHP_QUERY_RFC3986) : $params;
                 break;
             }
             case 'HEAD': {

--- a/OAuth2.php
+++ b/OAuth2.php
@@ -97,11 +97,11 @@ class OAuth2 extends BaseOAuth
      * Composes HTTP request CUrl options, which will be merged with the default ones.
      * @param string $method request type.
      * @param string $url request URL.
-     * @param array $params request params.
+     * @param mixed $params request params.
      * @return array CUrl options.
      * @throws Exception on failure.
      */
-    protected function composeRequestCurlOptions($method, $url, array $params)
+    protected function composeRequestCurlOptions($method, $url, $params)
     {
         $curlOptions = [];
         switch ($method) {
@@ -111,7 +111,7 @@ class OAuth2 extends BaseOAuth
             }
             case 'POST': {
                 $curlOptions[CURLOPT_POST] = true;
-                $curlOptions[CURLOPT_POSTFIELDS] = !$this->paramsHaveFile($params) ? http_build_query($params, null, '&', PHP_QUERY_RFC3986) : $params;
+                $curlOptions[CURLOPT_POSTFIELDS] = !parent::paramsHaveFile($params) ? (is_array($params) || is_object($params)) ? http_build_query($params, null, '&', PHP_QUERY_RFC3986) : $params : $params;
                 break;
             }
             case 'HEAD': {
@@ -135,7 +135,7 @@ class OAuth2 extends BaseOAuth
     /**
      * @inheritdoc
      */
-    protected function apiInternal($accessToken, $url, $method, array $params, array $headers)
+    protected function apiInternal($accessToken, $url, $method, $params, array $headers)
     {
         $params['access_token'] = $accessToken->getToken();
 

--- a/clients/LinkedIn.php
+++ b/clients/LinkedIn.php
@@ -132,9 +132,9 @@ class LinkedIn extends OAuth2
     /**
      * @inheritdoc
      */
-    protected function apiInternal($accessToken, $url, $method, array $params, array $headers)
+    protected function apiInternal($accessToken, $url, $method, $params, array $headers)
     {
-        $params['oauth2_access_token'] = $accessToken->getToken();
+        $headers = array_merge($headers, ['Authorization: Bearer '.$accessToken->getToken()]);
 
         return $this->sendRequest($method, $url, $params, $headers);
     }

--- a/clients/Sutton.php
+++ b/clients/Sutton.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace yii\authclient\clients;
+
+use yii\authclient\OAuth2;
+use yii\web\HttpException;
+use Yii;
+
+/**
+ * Sutton allows authentication via Sutton OAuth.
+ *
+ * In order to use sutton OAuth you must register with Sutton
+ *
+ * Example application configuration:
+ *
+ * ~~~
+ * 'components' => [
+ *     'authClientCollection' => [
+ *         'class' => 'yii\authclient\Collection',
+ *         'clients' => [
+ *             'sutton' => [
+ *                 'class' => 'yii\authclient\clients\Sutton',
+ *                 'clientId' => 'sutton_client_id',
+ *                 'clientSecret' => 'sutton_client_secret',
+ *                 'username' => 'sutton_username',
+ *                 'password' => 'sutton_password',
+ *             ],
+ *         ],
+ *     ]
+ *     ...
+ * ]
+ * ~~~
+ *
+ * @see http://docs.suttonapi.apiary.io/
+ *
+ * @author Steve Morocho <steve.morocho@backatyou.com>
+ */
+class Sutton extends OAuth2
+{
+    /**
+     * @inheritdoc
+     */
+    public $tokenUrl = 'https://staging-api.sutton.com/v1/oauth2/token';
+    /**
+     * @inheritdoc
+     */
+    public $apiBaseUrl = 'https://staging-api.sutton.com/v1';
+    /**
+     * @var array list of attribute names, which should be requested from API to initialize user attributes.
+     * @since 2.0.4
+     */
+    public $attributeNames = [
+        'id',
+    	'username',
+        'email',
+        'first_name',
+    	'middle_name',
+        'last_name',
+    	'preferred_first_name',
+        'picture_file_id'
+    ];
+
+    /**
+     * @var string Sutton provided username
+     */
+    public $username;
+    public $password;
+
+    /**
+     * @inheritdoc
+     */
+    protected function initUserAttributes()
+    {
+    	return $this->api('oauth2/me', 'GET');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function defaultName()
+    {
+        return 'sutton';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function defaultTitle()
+    {
+        return 'Sutton';
+    }
+}

--- a/clients/Sutton.php
+++ b/clients/Sutton.php
@@ -40,11 +40,11 @@ class Sutton extends OAuth2
     /**
      * @inheritdoc
      */
-    public $tokenUrl = 'https://staging-api.sutton.com/v1/oauth2/token';
+    public $tokenUrl = 'https://api.sutton.com/v1/oauth2/token';
     /**
      * @inheritdoc
      */
-    public $apiBaseUrl = 'https://staging-api.sutton.com/v1';
+    public $apiBaseUrl = 'https://api.sutton.com/v1';
     /**
      * @var array list of attribute names, which should be requested from API to initialize user attributes.
      * @since 2.0.4


### PR DESCRIPTION
Source: (http://php.net/manual/en/function.curl-setopt.php)

Whereas CURLOPT_POSTFIELDS 'can either be passed as a urlencoded string [...] or as an array with the field name as key and field data as value' 
Whereas 'Passing an array to CURLOPT_POSTFIELDS will encode the data as multipart/form-data, while passing a URL-encoded string will encode the data as application/x-www-form-urlencoded' 

I propose changes to yii2-authclient to allow for $params to be either an array or string.
Setting Content-Type explicitly is not required in composeRequestCurlOptions().
Also, determining when to use http_build_query depends on if array has any CURLFiles or not.
LinkedIn.php is changed to pass authToken in headers to allow for JSON api requests such as

	// get session session with user access token
	$token = new OAuthToken([
		'token' => 'ACCESS_TOKEN',
	]);
	$linkedin = new LinkedIn([
		'accessToken' => $token,
		'clientId' => 'CLIENT_ID',
		'clientSecret' => 'CLIENT_SECRET'
	]);
                         
	$data = [
		'comment' => 'Hello World',
		'visibility'=> ['code'=>'anyone']
	];
	try {
		$linkedin_response = $linkedin->api('people/~/shares?format=json', 'POST', json_encode($data), ['Content-Type: application/json']);
		$linkedin_updateKey = $linkedin_response['updateKey'];
	} catch(\Exception $ex) {
		error_log("Linkedin error posting message: " . var_export($ex->getMessage(), true));
	}