### PR TITLE
Fix facebook alert

### DIFF
--- a/assets/authchoice.js
+++ b/assets/authchoice.js
@@ -21,7 +21,7 @@ jQuery(function($) {
                 directories: 'no',
                 status: 'yes',
                 width: 450,
-                height: 380
+                height: 410
             }
         }, options);
 


### PR DESCRIPTION
Facebook authorization is impossible when window is less then or equals 400px.