### PR TITLE
misprint?

### DIFF
--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -31,8 +31,8 @@ class SiteController extends Controller
         
         if (Yii::$app->user->isGuest) {
             if ($auth) { // login
-                $user = $auth->user;
-                Yii::$app->user->login($user);
+                $user_id = $auth->user_id;
+                Yii::$app->user->login($user_id);
             } else { // signup
                 if (isset($attributes['email']) && User::find()->where(['email' => $attributes['email']])->exists()) {
                     Yii::$app->getSession()->setFlash('error', [


### PR DESCRIPTION
I think here we want to use user_id column from table Auth.

Because in https://github.com/yiisoft/yii2-authclient/blob/master/docs/guide/installation.md
sql dump of table Auth is:
CREATE TABLE auth (
    id int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,
    user_id int(11) NOT NULL,
    source varchar(255) NOT NULL,
    source_id varchar(255) NOT NULL
);

there is not column "user", but we can see column user_id.

Then Yii::$app->user->login(); want to take 1 argument user_id not is user