### PR TITLE
(Issue #77) More flexible urls

### DIFF
--- a/BaseOAuth.php
+++ b/BaseOAuth.php
@@ -100,6 +100,14 @@ abstract class BaseOAuth extends BaseClient implements ClientInterface
     }
 
     /**
+     * @return string API base URL.
+     */
+    public function getApiBaseUrl()
+    {        
+        return $this->apiBaseUrl;
+    }
+
+    /**
      * @param array $curlOptions cURL options.
      */
     public function setCurlOptions(array $curlOptions)
@@ -500,7 +508,7 @@ abstract class BaseOAuth extends BaseClient implements ClientInterface
         if (preg_match('/^https?:\\/\\//is', $apiSubUrl)) {
             $url = $apiSubUrl;
         } else {
-            $url = $this->apiBaseUrl . '/' . $apiSubUrl;
+            $url = $this->getApiBaseUrl() . '/' . $apiSubUrl;
         }
         $accessToken = $this->getAccessToken();
         if (!is_object($accessToken) || !$accessToken->getIsValid()) {

--- a/BaseOAuth.php
+++ b/BaseOAuth.php
@@ -92,6 +92,14 @@ abstract class BaseOAuth extends BaseClient implements ClientInterface
     }
 
     /**
+     * @return string auth URL.
+     */
+    public function getAuthUrl()
+    {        
+        return $this->authUrl;
+    }
+
+    /**
      * @param array $curlOptions cURL options.
      */
     public function setCurlOptions(array $curlOptions)
@@ -475,7 +483,7 @@ abstract class BaseOAuth extends BaseClient implements ClientInterface
      */
     protected function getStateKeyPrefix()
     {
-        return get_class($this) . '_' . sha1($this->authUrl) . '_';
+        return get_class($this) . '_' . sha1($this->getAuthUrl()) . '_';
     }
 
     /**

--- a/OAuth1.php
+++ b/OAuth1.php
@@ -64,6 +64,22 @@ class OAuth1 extends BaseOAuth
 
 
     /**
+     * @return string request token URL.
+     */
+    public function getRequestTokenUrl()
+    {        
+        return $this->requestTokenUrl;
+    }
+    
+    /**
+     * @return string access token URL.
+     */
+    public function getAccessTokenUrl()
+    {        
+        return $this->accessTokenUrl;
+    }
+
+    /**
      * Fetches the OAuth request token.
      * @param array $params additional request params.
      * @return OAuthToken request token.
@@ -79,7 +95,7 @@ class OAuth1 extends BaseOAuth
         if (!empty($this->scope)) {
             $defaultParams['scope'] = $this->scope;
         }
-        $response = $this->sendSignedRequest($this->requestTokenMethod, $this->requestTokenUrl, array_merge($defaultParams, $params));
+        $response = $this->sendSignedRequest($this->requestTokenMethod, $this->getRequestTokenUrl(), array_merge($defaultParams, $params));
         $token = $this->createToken([
             'params' => $response
         ]);
@@ -137,7 +153,7 @@ class OAuth1 extends BaseOAuth
         if (!empty($oauthVerifier)) {
             $defaultParams['oauth_verifier'] = $oauthVerifier;
         }
-        $response = $this->sendSignedRequest($this->accessTokenMethod, $this->accessTokenUrl, array_merge($defaultParams, $params));
+        $response = $this->sendSignedRequest($this->accessTokenMethod, $this->getAccessTokenUrl(), array_merge($defaultParams, $params));
 
         $token = $this->createToken([
             'params' => $response

--- a/OAuth1.php
+++ b/OAuth1.php
@@ -105,7 +105,7 @@ class OAuth1 extends BaseOAuth
         }
         $params['oauth_token'] = $requestToken->getToken();
 
-        return $this->composeUrl($this->authUrl, $params);
+        return $this->composeUrl($this->getAuthUrl(), $params);
     }
 
     /**

--- a/OAuth2.php
+++ b/OAuth2.php
@@ -68,7 +68,7 @@ class OAuth2 extends BaseOAuth
             $defaultParams['scope'] = $this->scope;
         }
 
-        return $this->composeUrl($this->authUrl, array_merge($defaultParams, $params));
+        return $this->composeUrl($this->getAuthUrl(), array_merge($defaultParams, $params));
     }
 
     /**

--- a/OAuth2.php
+++ b/OAuth2.php
@@ -50,6 +50,14 @@ class OAuth2 extends BaseOAuth
      */
     public $tokenUrl;
 
+    /**
+     * @return string token URL.
+     */
+    public function getTokenUrl()
+    {
+        return $this->tokenUrl;
+    }
+
 
     /**
      * Composes user authorization URL.
@@ -86,7 +94,7 @@ class OAuth2 extends BaseOAuth
             'grant_type' => 'authorization_code',
             'redirect_uri' => $this->getReturnUrl(),
         ];
-        $response = $this->sendRequest('POST', $this->tokenUrl, array_merge($defaultParams, $params));
+        $response = $this->sendRequest('POST', $this->getTokenUrl(), array_merge($defaultParams, $params));
         $token = $this->createToken(['params' => $response]);
         $this->setAccessToken($token);
 
@@ -156,7 +164,7 @@ class OAuth2 extends BaseOAuth
             'grant_type' => 'refresh_token'
         ];
         $params = array_merge($token->getParams(), $params);
-        $response = $this->sendRequest('POST', $this->tokenUrl, $params);
+        $response = $this->sendRequest('POST', $this->getTokenUrl(), $params);
 
         $token = $this->createToken(['params' => $response]);
         $this->setAccessToken($token);

--- a/OpenId.php
+++ b/OpenId.php
@@ -657,7 +657,7 @@ class OpenId extends BaseClient implements ClientInterface
      */
     public function buildAuthUrl($identifierSelect = null)
     {
-        $authUrl = $this->authUrl;
+        $authUrl = $this->getAuthUrl();
         $claimedId = $this->getClaimedId();
         if (empty($claimedId)) {
             $this->setClaimedId($authUrl);


### PR DESCRIPTION
See Issue #77 

Now one can construct more flexible urls for auth clients. Example:
```php
    public $wikiDomain; // configurable

    public $authUrl_path = '/initiate?format=json&oauth_callback=oob';


    public function getBaseUrl()
    {    
        return "https://" . $this->wikiDomain . ".wikipedia.org/wiki/Special:OAuth";
    }

    /**
     * @inheritdoc
     */
    public function getAuthUrl()
    {
        return $this->getBaseUrl() . $this->authUrl_path;
    }
```