### PR TITLE
Update example in comments.

### DIFF
--- a/Collection.php
+++ b/Collection.php
@@ -22,8 +22,10 @@ use Yii;
  *         'class' => 'yii\authclient\Collection',
  *         'clients' => [
  *             'google' => [
- *                 'class' => 'yii\authclient\clients\GoogleOpenId'
- *             ],
+                    'class' => 'yii\authclient\clients\GoogleOAuth',
+                    'clientId' => 'google_client_id',
+                    'clientSecret' => 'google_client_secret',
+                ],
  *             'facebook' => [
  *                 'class' => 'yii\authclient\clients\Facebook',
  *                 'clientId' => 'facebook_client_id',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

I remove GoogleOpenId class in `yii\authclient\Collection` example, Also change in your official docs http://www.yiiframework.com/doc-2.0/yii-authclient-collection.html.

Because this auth method is no longer supported by Google as of April 20, 2015 and also you are deprecated since version 2.0.4.