### PR TITLE
Add `state` logic for Google and GitHub clients

### DIFF
--- a/clients/GitHub.php
+++ b/clients/GitHub.php
@@ -7,6 +7,7 @@
 
 namespace yii\authclient\clients;
 
+use Yii;
 use yii\authclient\OAuth2;
 use yii\web\BadRequestHttpException;
 
@@ -142,5 +143,18 @@ class GitHub extends OAuth2
         $params['state'] = $authState;
 
         return parent::buildAuthUrl($params);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function defaultReturnUrl()
+    {
+        $params = $_GET;
+        unset($params['code']);
+        unset($params['state']);
+        $params[0] = Yii::$app->controller->getRoute();
+
+        return Yii::$app->getUrlManager()->createAbsoluteUrl($params);
     }
 }

--- a/clients/Google.php
+++ b/clients/Google.php
@@ -1,12 +1,13 @@
 <?php
 /**
- * @link      http://www.yiiframework.com/
+ * @link http://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
- * @license   http://www.yiiframework.com/license/
+ * @license http://www.yiiframework.com/license/
  */
 
 namespace yii\authclient\clients;
 
+use Yii;
 use yii\authclient\OAuth2;
 use yii\web\BadRequestHttpException;
 
@@ -128,5 +129,18 @@ class Google extends OAuth2
         $params['state'] = $authState;
 
         return parent::buildAuthUrl($params);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function defaultReturnUrl()
+    {
+        $params = $_GET;
+        unset($params['code']);
+        unset($params['state']);
+        $params[0] = Yii::$app->controller->getRoute();
+
+        return Yii::$app->getUrlManager()->createAbsoluteUrl($params);
     }
 }

--- a/clients/Google.php
+++ b/clients/Google.php
@@ -1,13 +1,14 @@
 <?php
 /**
- * @link http://www.yiiframework.com/
+ * @link      http://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
- * @license http://www.yiiframework.com/license/
+ * @license   http://www.yiiframework.com/license/
  */
 
 namespace yii\authclient\clients;
 
 use yii\authclient\OAuth2;
+use yii\web\BadRequestHttpException;
 
 /**
  * Google allows authentication via Google OAuth.
@@ -35,10 +36,10 @@ use yii\authclient\OAuth2;
  * ]
  * ```
  *
- * @see https://console.developers.google.com/project
+ * @see    https://console.developers.google.com/project
  *
  * @author Paul Klimov <klimov.paul@gmail.com>
- * @since 2.0
+ * @since  2.0
  */
 class Google extends OAuth2
 {
@@ -54,7 +55,6 @@ class Google extends OAuth2
      * @inheritdoc
      */
     public $apiBaseUrl = 'https://www.googleapis.com/plus/v1';
-
 
     /**
      * @inheritdoc
@@ -92,5 +92,41 @@ class Google extends OAuth2
     protected function defaultTitle()
     {
         return 'Google';
+    }
+
+    /**
+     * Generates the auth state value.
+     * @return string auth state value.
+     */
+    protected function generateAuthState()
+    {
+        return sha1(uniqid(get_class($this), true));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function fetchAccessToken($authCode, array $params = [])
+    {
+        $authState = $this->getState('authState');
+        if (!isset($_REQUEST['state']) || empty($authState) || strcmp($_REQUEST['state'], $authState) !== 0) {
+            throw new BadRequestHttpException('Invalid auth state parameter.');
+        } else {
+            $this->removeState('authState');
+        }
+
+        return parent::fetchAccessToken($authCode, $params);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function buildAuthUrl(array $params = [])
+    {
+        $authState = $this->generateAuthState();
+        $this->setState('authState', $authState);
+        $params['state'] = $authState;
+
+        return parent::buildAuthUrl($params);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no (it's an improvement to two existing clients)
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | N/A

Add logic for setting and validating a `state` query parameter when
redirecting to Google and GitHub and handling their roundtrip requests.
Both Google and GitHub support and return the `state` query parameter
when passed in the auth URL. Ref:
https://developers.google.com/identity/protocols/OAuth2WebServer#redirecting,
https://developer.github.com/v3/oauth/#parameters.