### PR TITLE
add addAuthorizationHeader option

### DIFF
--- a/OAuth1.php
+++ b/OAuth1.php
@@ -64,6 +64,11 @@ abstract class OAuth1 extends BaseOAuth
      */
     public $accessTokenMethod = 'GET';
 
+    /**
+     * @var null|bool add an Authorization header when signing a request (leave null for auto-detect)
+     */
+    public $addAuthorizationHeader = null;
+
 
     /**
      * Fetches the OAuth request token.
@@ -313,7 +318,9 @@ abstract class OAuth1 extends BaseOAuth
 
         $request->setData($params);
 
-        if (strcasecmp($request->getMethod(), 'POST') === 0) {
+        if ($this->addAuthorizationHeader ||
+            (is_null($this->addAuthorizationHeader) && strcasecmp($request->getMethod(), 'POST') === 0)
+        ) {
             $authorizationHeader = $this->composeAuthorizationHeader($params);
             if (!empty($authorizationHeader)) {
                 $request->addHeaders($authorizationHeader);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | -

Some Oauth1 implementation (like Magento 2) require an Authorization header for all methods.
This PR allows to set 'addAuthorizationHeader' to true to force the addition of the header (or to false to never include it).