### PR TITLE
Add Facebook 'appsecret_proof' request param  (fixes #67)

### DIFF
--- a/clients/Facebook.php
+++ b/clients/Facebook.php
@@ -102,4 +102,15 @@ class Facebook extends OAuth2
             'popupHeight' => 480,
         ];
     }
+    
+    /**
+     * @inheritdoc
+     */
+    public function applyAccessTokenToRequest($request, $accessToken)
+    {
+        $data = $request->getData();
+        $data['access_token'] = $accessToken->getToken();
+        $data['appsecret_proof'] = hash_hmac('sha256', $accessToken->getToken(), $this->clientSecret);
+        $request->setData($data);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #67 

Fixes `"API calls from the server require an appsecret_proof argument` Facebook error