### PR TITLE
Fix #163: Added support for access token exchange and client-specific access tokens at `Facebook`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ Yii Framework 2 authclient extension Change Log
 - Enh #156: Added `\yii\authclient\signature\RsaSha` and `\yii\authclient\signature\HmacSha` supporting general 'SHAwithRSA' and 'HMAC SHA' signature methods (klimov-paul)
 - Enh #157: Added `\yii\authclient\OAuth2::authenticateUserJwt()` supporting authentication via JSON Web Token (JWT) (klimov-paul)
 - Enh #163: Added support for exchanging access token at `yii\authclient\clients\Facebook` (klimov-paul)
-- Enh: Added support for client-specific access tokens at `yii\authclient\clients\Facebook` (klimov-paul)
-- Chg: `yii\authclient\clients\Facebook::$autoRefreshAccessToken` is now disabled by default (klimov-paul)
+- Enh #163: Added support for client-specific access tokens at `yii\authclient\clients\Facebook` (klimov-paul)
+- Chg #163: `yii\authclient\clients\Facebook::$autoRefreshAccessToken` is now disabled by default (klimov-paul)
 
 
 2.1.2 February 15, 2017

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Yii Framework 2 authclient extension Change Log
 - Enh #155: Added `\yii\authclient\OpenIdConnect` supporting [OpenID Connect](http://openid.net/connect/) protocol (klimov-paul)
 - Enh #156: Added `\yii\authclient\signature\RsaSha` and `\yii\authclient\signature\HmacSha` supporting general 'SHAwithRSA' and 'HMAC SHA' signature methods (klimov-paul)
 - Enh #157: Added `\yii\authclient\OAuth2::authenticateUserJwt()` supporting authentication via JSON Web Token (JWT) (klimov-paul)
+- Enh #163: Added support for exchanging access token at `yii\authclient\clients\Facebook` (klimov-paul)
+- Enh: Added support for client-specific access tokens at `yii\authclient\clients\Facebook` (klimov-paul)
+- Chg: `yii\authclient\clients\Facebook::$autoRefreshAccessToken` is now disabled by default (klimov-paul)
 
 
 2.1.2 February 15, 2017

--- a/clients/Facebook.php
+++ b/clients/Facebook.php
@@ -103,6 +103,9 @@ class Facebook extends OAuth2
         parent::applyAccessTokenToRequest($request, $accessToken);
 
         $data = $request->getData();
+        if (($machineId = $accessToken->getParam('machine_id')) !== null) {
+            $data['machine_id'] = $machineId;
+        }
         $data['appsecret_proof'] = hash_hmac('sha256', $accessToken->getToken(), $this->clientSecret);
         $request->setData($data);
     }

--- a/clients/Facebook.php
+++ b/clients/Facebook.php
@@ -8,6 +8,7 @@
 namespace yii\authclient\clients;
 
 use yii\authclient\OAuth2;
+use yii\authclient\OAuthToken;
 
 /**
  * Facebook allows authentication via Facebook OAuth.
@@ -64,6 +65,24 @@ class Facebook extends OAuth2
         'name',
         'email',
     ];
+    /**
+     * @inheritdoc
+     */
+    public $autoRefreshAccessToken = false; // Facebook does not provide access token refreshment
+    /**
+     * @var bool whether to automatically upgrade short-live (2 hours) access token to long-live (60 days) one, after fetching it.
+     * @see exchangeToken()
+     * @since 2.1.3
+     */
+    public $autoExchangeAccessToken = false;
+    /**
+     * @var string URL endpoint for the client auth code generation.
+     * @see https://developers.facebook.com/docs/facebook-login/access-tokens/expiration-and-extension
+     * @see fetchClientAuthCode()
+     * @see fetchClientAccessToken()
+     * @since 2.1.3
+     */
+    public $clientAuthCodeUrl = 'https://graph.facebook.com/oauth/client_code';
 
 
     /**
@@ -113,5 +132,114 @@ class Facebook extends OAuth2
             'popupWidth' => 860,
             'popupHeight' => 480,
         ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function fetchAccessToken($authCode, array $params = [])
+    {
+        $token = parent::fetchAccessToken($authCode, $params);
+        if ($this->autoExchangeAccessToken) {
+            $token = $this->exchangeAccessToken($token);
+        }
+        return $token;
+    }
+
+    /**
+     * Exchanges short-live (2 hours) access token to long-live (60 days) one.
+     * Note that this method will success for already long-live token, but will not actually prolong it any further.
+     * Pay attention, that this method will fail on already expired access token.
+     * @see https://developers.facebook.com/docs/facebook-login/access-tokens/expiration-and-extension
+     * @param OAuthToken $token short-live access token.
+     * @return OAuthToken long-live access token.
+     * @since 2.1.3
+     */
+    public function exchangeAccessToken(OAuthToken $token)
+    {
+        $params = [
+            'grant_type' => 'fb_exchange_token',
+            'fb_exchange_token' => $token->getToken(),
+        ];
+
+        $request = $this->createRequest()
+            ->setMethod('POST')
+            ->setUrl($this->tokenUrl)
+            ->setData($params);
+
+        $this->applyClientCredentialsToRequest($request);
+
+        $response = $this->sendRequest($request);
+
+        $token = $this->createToken(['params' => $response]);
+        $this->setAccessToken($token);
+
+        return $token;
+    }
+
+    /**
+     * Requests the authorization code for the client-specific access token.
+     * This make sense for the distributed applications, which provides several Auth clients (web and mobile)
+     * to avoid triggering Facebook's automated spam systems.
+     * @see https://developers.facebook.com/docs/facebook-login/access-tokens/expiration-and-extension
+     * @see fetchClientAccessToken()
+     * @param OAuthToken|null $token access token, if not set [[accessToken]] will be used.
+     * @param array $params additional request params.
+     * @return string client auth code.
+     * @since 2.1.3
+     */
+    public function fetchClientAuthCode(OAuthToken $token = null, $params = [])
+    {
+        if ($token === null) {
+            $token = $this->getAccessToken();
+        }
+
+        $params = array_merge([
+            'access_token' => $token->getToken(),
+            'redirect_uri' => $this->getReturnUrl(),
+        ], $params);
+
+        $request = $this->createRequest()
+            ->setMethod('POST')
+            ->setUrl($this->clientAuthCodeUrl)
+            ->setData($params);
+
+        $this->applyClientCredentialsToRequest($request);
+
+        $response = $this->sendRequest($request);
+
+        return $response['code'];
+    }
+
+    /**
+     * Fetches access token from client-specific authorization code.
+     * This make sense for the distributed applications, which provides several Auth clients (web and mobile)
+     * to avoid triggering Facebook's automated spam systems.
+     * @see https://developers.facebook.com/docs/facebook-login/access-tokens/expiration-and-extension
+     * @see fetchClientAuthCode()
+     * @param string $authCode client auth code.
+     * @param array $params
+     * @return OAuthToken long-live client-specific access token.
+     * @since 2.1.3
+     */
+    public function fetchClientAccessToken($authCode, array $params = [])
+    {
+        $params = array_merge([
+            'code' => $authCode,
+            'redirect_uri' => $this->getReturnUrl(),
+            'client_id' => $this->clientId,
+        ], $params);
+
+        $request = $this->createRequest()
+            ->setMethod('POST')
+            ->setUrl($this->tokenUrl)
+            ->setData($params);
+
+        $response = $this->sendRequest($request);
+
+        $token = $this->createToken(['params' => $response]);
+        $this->setAccessToken($token);
+
+        return $token;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #163
