### PR TITLE
Update comments to proper fetchAccessToken usage

### DIFF
--- a/OAuth1.php
+++ b/OAuth1.php
@@ -25,7 +25,7 @@ use yii\web\HttpException;
  * $url = $oauthClient->buildAuthUrl($requestToken); // Get authorization URL
  * return Yii::$app->getResponse()->redirect($url); // Redirect to authorization URL
  * // After user returns at our site:
- * $accessToken = $oauthClient->fetchAccessToken($requestToken); // Upgrade to access token
+ * $accessToken = $oauthClient->fetchAccessToken(null,$requestToken); // Upgrade to access token
  * ```
  *
  * @see https://oauth.net/1/


### PR DESCRIPTION
fetchAccessToken expects (string)$oauthToken  as first argument and $requestToken as second.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | no
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
