### PR TITLE
Missing $key in openssl_pkey_get_private()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 authclient extension Change Log
 -----------------------
 
 - Enh #203: Updated VKontakte client to use API version 5.0 (Shketkol)
+- Bug #211: `RsaSha` was not passing `$key` to `openssl_pkey_get_private()` in `generateSignature()` (cfhodges)
 
 
 2.1.5 February 08, 2018

--- a/src/signature/RsaSha.php
+++ b/src/signature/RsaSha.php
@@ -168,7 +168,7 @@ class RsaSha extends BaseMethod
     {
         $privateCertificateContent = $this->getPrivateCertificate();
         // Pull the private key ID from the certificate
-        $privateKeyId = openssl_pkey_get_private($privateCertificateContent);
+        $privateKeyId = openssl_pkey_get_private($privateCertificateContent, $key);
         // Sign using the key
         openssl_sign($baseString, $signature, $privateKeyId, $this->algorithm);
         // Release the key resource


### PR DESCRIPTION
This addresses issue #211

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | yes/no
| Tests pass?   | yes/no
| Fixed issues  | #211 
