### PR TITLE
Unset parameter `scope` on `defaultReturnUrl` for `OAuth2`, fixing bug #241

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 authclient extension Change Log
 2.1.7 under development
 -----------------------
 
-- no changes in this release.
+- Bug #241: Unset parameter `scope` on `defaultReturnUrl` for `OAuth2` class since it was causing bad request response from providers -Google- (okiwan)
 
 
 2.1.6 September 07, 2018

--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -189,6 +189,7 @@ abstract class OAuth2 extends BaseOAuth
         $params = Yii::$app->getRequest()->getQueryParams();
         unset($params['code']);
         unset($params['state']);
+        unset($params['scope']);
         $params[0] = Yii::$app->controller->getRoute();
 
         return Yii::$app->getUrlManager()->createAbsoluteUrl($params);


### PR DESCRIPTION
…g #241

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #241 
