### PR TITLE
fix: redirect from linkedIn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 authclient extension Change Log
 2.1.8 under development
 -----------------------
 
-- no changes in this release.
+- Bug #237: Fix redirect from linkedIn if user  user refused to authorize permissions request (jakim)
 
 
 2.1.7 September 20, 2018

--- a/src/AuthAction.php
+++ b/src/AuthAction.php
@@ -375,7 +375,11 @@ class AuthAction extends Action
         $request = Yii::$app->getRequest();
 
         if (($error = $request->get('error')) !== null) {
-            if ($error === 'access_denied' || $error === 'user_cancelled_login') {
+            if (
+                $error === 'access_denied' ||
+                $error === 'user_cancelled_login' ||
+                $error === 'user_cancelled_authorize'
+            ) {
                 // user denied error
                 return $this->authCancel($client);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  | #234 

As LinkedIn's documentation says, there are two possible parameters when canceling the authorization:

- `user_cancelled_login` - The user refused to login into LinkedIn account.

- `user_cancelled_authorize` - The user refused to authorize permissions request from your application.

See https://developer.linkedin.com/docs/oauth2, section "Application is rejected"
