### PR TITLE
allow to pass buildAuthUrl params to OAuth flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Yii Framework 2 authclient extension Change Log
 2.1.8 under development
 -----------------------
 
+- Enh #259: Allow to pass buildAuthUrl params to OAuth flows in `AuthAction` (albertborsos)
 - Enh #218: Allow configuring user component in `AuthAction` (samdark, lab362)
 - Bug #237: Fix redirect from LinkedIn if user refused to authorize permissions request (jakim)
 

--- a/src/AuthAction.php
+++ b/src/AuthAction.php
@@ -216,15 +216,16 @@ class AuthAction extends Action
     /**
      * Perform authentication for the given client.
      * @param mixed $client auth client instance.
+     * @param array $authUrlParams additional auth GET params.
      * @return Response response instance.
      * @throws \yii\base\NotSupportedException on invalid client.
      */
-    protected function auth($client)
+    protected function auth($client, $authUrlParams = [])
     {
         if ($client instanceof OAuth2) {
-            return $this->authOAuth2($client);
+            return $this->authOAuth2($client, $authUrlParams);
         } elseif ($client instanceof OAuth1) {
-            return $this->authOAuth1($client);
+            return $this->authOAuth1($client, $authUrlParams);
         } elseif ($client instanceof OpenId) {
             return $this->authOpenId($client);
         }
@@ -355,9 +356,10 @@ class AuthAction extends Action
     /**
      * Performs OAuth1 auth flow.
      * @param OAuth1 $client auth client instance.
+     * @param array $authUrlParams additional auth GET params.
      * @return Response action response.
      */
-    protected function authOAuth1($client)
+    protected function authOAuth1($client, $authUrlParams = [])
     {
         $request = Yii::$app->getRequest();
 
@@ -375,7 +377,7 @@ class AuthAction extends Action
         // Get request token.
         $requestToken = $client->fetchRequestToken();
         // Get authorization URL.
-        $url = $client->buildAuthUrl($requestToken);
+        $url = $client->buildAuthUrl($requestToken, $authUrlParams);
         // Redirect to authorization URL.
         return Yii::$app->getResponse()->redirect($url);
     }
@@ -383,10 +385,11 @@ class AuthAction extends Action
     /**
      * Performs OAuth2 auth flow.
      * @param OAuth2 $client auth client instance.
+     * @param array $authUrlParams additional auth GET params.
      * @return Response action response.
      * @throws \yii\base\Exception on failure.
      */
-    protected function authOAuth2($client)
+    protected function authOAuth2($client, $authUrlParams = [])
     {
         $request = Yii::$app->getRequest();
 
@@ -416,7 +419,7 @@ class AuthAction extends Action
             return $this->authCancel($client);
         }
 
-        $url = $client->buildAuthUrl();
+        $url = $client->buildAuthUrl($authUrlParams);
         return Yii::$app->getResponse()->redirect($url);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 

I often want to use a custom state token, because I need to access data after the successful authentication. That's why I put a payload into my custom state token.

Now, I need to duplicate the complete `authOAuth2` method to inject my custom state token into the auth url.

This PR allows to pass the `$params` attribute to `buildAuthUrl()` method without duplicating the complete `authOAuth2` method, but overriding only the `run()` method.