### PR TITLE
Use oauth2 Google API endpoint instead of plus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Yii Framework 2 authclient extension Change Log
 - Enh #259: Allow to pass buildAuthUrl params to OAuth flows in `AuthAction` (albertborsos)
 - Enh #218: Allow configuring user component in `AuthAction` (samdark, lab362)
 - Bug #237: Fix redirect from LinkedIn if user refused to authorize permissions request (jakim)
+- Enh #258: Use Google Sign-in API instead of Google Plus in `yii\authclient\clients\Google` as Google Plus is deprecated (alexeevdv) 
 
 
 2.1.7 September 20, 2018

--- a/src/clients/Google.php
+++ b/src/clients/Google.php
@@ -13,9 +13,7 @@ use yii\authclient\OAuth2;
  * Google allows authentication via Google OAuth.
  *
  * In order to use Google OAuth you must create a project at <https://console.developers.google.com/project>
- * and setup its credentials at <https://console.developers.google.com/project/[yourProjectId]/apiui/credential>.
- * In order to enable using scopes for retrieving user attributes, you should also enable Google+ API at
- * <https://console.developers.google.com/project/[yourProjectId]/apiui/api/plus>
+ * and setup its credentials at <https://console.developers.google.com/apis/credentials?project=[yourProjectId]>.
  *
  * Example application configuration:
  *
@@ -53,7 +51,7 @@ class Google extends OAuth2
     /**
      * {@inheritdoc}
      */
-    public $apiBaseUrl = 'https://www.googleapis.com/plus/v1';
+    public $apiBaseUrl = 'https://www.googleapis.com/oauth2/v1';
 
 
     /**
@@ -64,8 +62,8 @@ class Google extends OAuth2
         parent::init();
         if ($this->scope === null) {
             $this->scope = implode(' ', [
-                'profile',
-                'email',
+                'https://www.googleapis.com/auth/userinfo.profile',
+                'https://www.googleapis.com/auth/userinfo.email',
             ]);
         }
     }
@@ -75,7 +73,7 @@ class Google extends OAuth2
      */
     protected function initUserAttributes()
     {
-        return $this->api('people/me', 'GET');
+        return $this->api('userinfo', 'GET');
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | yes
| Tests pass?   | yes
| Fixed issues  | #258 

It breaks backward compatibility because `initUserAttributes` now returns different set of attributes. But since it will stop working anyway (because G+ is deprecated) it is not such a big issue. End-user code that uses `yii\authclient\clients\Google` need to be rewritten anyway