### PR TITLE
Fixes #273: `OpenIdConnect::validateClaims()` is now protected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 authclient extension Change Log
 2.2.3 under development
 -----------------------
 
-- no changes in this release.
+- Chg #273: `OpenIdConnect::validateClaims()` is now protected (samdark)
 
 
 2.2.2 May 14, 2019

--- a/src/OpenIdConnect.php
+++ b/src/OpenIdConnect.php
@@ -378,8 +378,9 @@ class OpenIdConnect extends OAuth2
      * Validates the claims data received from OpenID provider.
      * @param array $claims claims data.
      * @throws HttpException on invalid claims.
+     * @since 2.2.3
      */
-    private function validateClaims(array $claims)
+    protected function validateClaims(array $claims)
     {
         if (!isset($claims['iss']) || (strcmp(rtrim($claims['iss'], '/'), rtrim($this->issuerUrl, '/')) !== 0)) {
             throw new HttpException(400, 'Invalid "iss"');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #273
