### PR TITLE
allow to set OAuth2 parameters to keep in default return url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 authclient extension Change Log
 -----------------------
 
 - Enh #276: Bumped VK API version to 5.95, according to developers recommendation (EvgeniyRRU)
+- Enh #278: keep only selected parameters in default return urls of OAuth services (albertborsos)
 
 
 2.2.3 June 04, 2019

--- a/src/BaseOAuth.php
+++ b/src/BaseOAuth.php
@@ -172,10 +172,7 @@ abstract class BaseOAuth extends BaseClient
     protected function defaultReturnUrl()
     {
         $params = Yii::$app->getRequest()->getQueryParams();
-
-        $params = array_filter($params, function ($value, $key) {
-            return in_array($key, $this->parametersToKeepInReturnUrl);
-        }, ARRAY_FILTER_USE_BOTH);
+        $params = array_intersect_key($params, array_flip($this->parametersToKeepInReturnUrl));
 
         $params[0] = Yii::$app->controller->getRoute();
 

--- a/src/BaseOAuth.php
+++ b/src/BaseOAuth.php
@@ -53,11 +53,11 @@ abstract class BaseOAuth extends BaseClient
     public $autoRefreshAccessToken = true;
     /**
      * @var array List of the parameters to keep in default return url.
+     * @since 2.2.4
      */
     public $parametersToKeepInReturnUrl = [
         'authclient',
     ];
-
     /**
      * @var string URL, which user will be redirected after authentication at the OAuth provider web site.
      * Note: this should be absolute URL (with http:// or https:// leading).

--- a/src/BaseOAuth.php
+++ b/src/BaseOAuth.php
@@ -51,6 +51,12 @@ abstract class BaseOAuth extends BaseClient
      * @since 2.0.6
      */
     public $autoRefreshAccessToken = true;
+    /**
+     * @var array List of the parameters to keep in default return url.
+     */
+    public $parametersToKeepInReturnUrl = [
+        'authclient',
+    ];
 
     /**
      * @var string URL, which user will be redirected after authentication at the OAuth provider web site.
@@ -165,7 +171,15 @@ abstract class BaseOAuth extends BaseClient
      */
     protected function defaultReturnUrl()
     {
-        return Yii::$app->getRequest()->getAbsoluteUrl();
+        $params = Yii::$app->getRequest()->getQueryParams();
+
+        $params = array_filter($params, function ($value, $key) {
+            return in_array($key, $this->parametersToKeepInReturnUrl);
+        }, ARRAY_FILTER_USE_BOTH);
+
+        $params[0] = Yii::$app->controller->getRoute();
+
+        return Yii::$app->getUrlManager()->createAbsoluteUrl($params);
     }
 
     /**

--- a/src/OAuth1.php
+++ b/src/OAuth1.php
@@ -247,19 +247,6 @@ abstract class OAuth1 extends BaseOAuth
     }
 
     /**
-     * Composes default [[returnUrl]] value.
-     * @return string return URL.
-     */
-    protected function defaultReturnUrl()
-    {
-        $params = Yii::$app->getRequest()->getQueryParams();
-        unset($params['oauth_token']);
-        $params[0] = Yii::$app->controller->getRoute();
-
-        return Yii::$app->getUrlManager()->createAbsoluteUrl($params);
-    }
-
-    /**
      * Generates nonce value.
      * @return string nonce value.
      */

--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -63,13 +63,6 @@ abstract class OAuth2 extends BaseOAuth
     public $validateAuthState = true;
 
     /**
-     * @var array List of the parameters to keep in default return url.
-     */
-    public $parametersToKeepInReturnUrl = [
-        'authclient',
-    ];
-
-    /**
      * Composes user authorization URL.
      * @param array $params additional auth GET params.
      * @return string authorization URL.
@@ -184,23 +177,6 @@ abstract class OAuth2 extends BaseOAuth
         $this->setAccessToken($token);
 
         return $token;
-    }
-
-    /**
-     * Composes default [[returnUrl]] value.
-     * @return string return URL.
-     */
-    protected function defaultReturnUrl()
-    {
-        $params = Yii::$app->getRequest()->getQueryParams();
-
-        $params = array_filter($params, function ($value, $key) {
-            return in_array($key, $this->parametersToKeepInReturnUrl);
-        }, ARRAY_FILTER_USE_BOTH);
-
-        $params[0] = Yii::$app->controller->getRoute();
-
-        return Yii::$app->getUrlManager()->createAbsoluteUrl($params);
     }
 
     /**

--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -62,6 +62,12 @@ abstract class OAuth2 extends BaseOAuth
      */
     public $validateAuthState = true;
 
+    /**
+     * @var array List of the parameters to keep in default return url.
+     */
+    public $parametersToKeepInReturnUrl = [
+        'authclient',
+    ];
 
     /**
      * Composes user authorization URL.
@@ -187,9 +193,11 @@ abstract class OAuth2 extends BaseOAuth
     protected function defaultReturnUrl()
     {
         $params = Yii::$app->getRequest()->getQueryParams();
-        unset($params['code']);
-        unset($params['state']);
-        unset($params['scope']);
+
+        $params = array_filter($params, function ($value, $key) {
+            return in_array($key, $this->parametersToKeepInReturnUrl);
+        }, ARRAY_FILTER_USE_BOTH);
+
         $params[0] = Yii::$app->controller->getRoute();
 
         return Yii::$app->getUrlManager()->createAbsoluteUrl($params);

--- a/src/OpenIdConnect.php
+++ b/src/OpenIdConnect.php
@@ -260,7 +260,7 @@ class OpenIdConnect extends OAuth2
     {
         return $this->api($this->getConfigParam('userinfo_endpoint'), 'GET');
     }
-	
+
     /**
      * {@inheritdoc}
      */
@@ -312,25 +312,6 @@ class OpenIdConnect extends OAuth2
         } else {
             throw new InvalidConfigException('Unable to authenticate request: none of following auth methods is suported: ' . implode(', ', $supportedAuthMethods));
         }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function defaultReturnUrl()
-    {
-        $params = Yii::$app->getRequest()->getQueryParams();
-        // OAuth2 specifics :
-        unset($params['code']);
-        unset($params['state']);
-        // OpenIdConnect specifics :
-        unset($params['nonce']);
-        unset($params['authuser']);
-        unset($params['session_state']);
-        unset($params['prompt']);
-        $params[0] = Yii::$app->controller->getRoute();
-
-        return Yii::$app->getUrlManager()->createAbsoluteUrl($params);
     }
 
     /**

--- a/tests/BaseOAuthTest.php
+++ b/tests/BaseOAuthTest.php
@@ -6,9 +6,12 @@ use yii\authclient\signature\PlainText;
 use yii\authclient\OAuthToken;
 use yii\authclient\BaseOAuth;
 use yii\httpclient\Client;
+use yiiunit\extensions\authclient\traits\OAuthDefaultReturnUrlTestTrait;
 
 class BaseOAuthTest extends TestCase
 {
+    use OAuthDefaultReturnUrlTestTrait;
+
     protected function setUp()
     {
         parent::setUp();
@@ -206,5 +209,18 @@ class BaseOAuthTest extends TestCase
             ->setUrl($apiSubUrl);
 
         $this->assertEquals($expectedApiFullUrl, $request->getFullUrl());
+    }
+
+    /**
+     * Data provider for [[testDefaultReturnUrl]].
+     * @return array test data.
+     */
+    public function defaultReturnUrlDataProvider()
+    {
+        return [
+            'default'                => [['authclient' => 'base'], null, '/?authclient=base'],
+            'remove extra parameter' => [['authclient' => 'base', 'extra' => 'userid'], null, '/?authclient=base'],
+            'keep extra parameter'   => [['authclient' => 'base', 'extra' => 'userid'], ['authclient', 'extra'], '/?authclient=base&extra=userid'],
+        ];
     }
 }

--- a/tests/clients/GoogleHybridTest.php
+++ b/tests/clients/GoogleHybridTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace yiiunit\extensions\authclient\clients;
+
+use yii\authclient\clients\GoogleHybrid;
+use yiiunit\extensions\authclient\TestCase;
+use yiiunit\extensions\authclient\traits\OAuthDefaultReturnUrlTestTrait;
+
+class GoogleHybridTest extends TestCase
+{
+    use OAuthDefaultReturnUrlTestTrait;
+
+    protected function createClient()
+    {
+        return new GoogleHybrid();
+    }
+
+    /**
+     * Data provider for [[testDefaultReturnUrl]].
+     * @return array test data.
+     */
+    public function defaultReturnUrlDataProvider()
+    {
+        return [
+            'default'                => [['authclient' => 'google-hybrid'], null, 'postmessage'],
+            'remove extra parameter' => [['authclient' => 'google-hybrid', 'extra' => 'userid'], null, 'postmessage'],
+            'keep extra parameter'   => [['authclient' => 'google-hybrid', 'extra' => 'userid'], ['authclient', 'extra'], 'postmessage'],
+        ];
+    }
+}

--- a/tests/clients/GoogleTest.php
+++ b/tests/clients/GoogleTest.php
@@ -6,12 +6,15 @@ use yii\authclient\clients\Google;
 use yii\authclient\OAuthToken;
 use yii\authclient\signature\RsaSha;
 use yiiunit\extensions\authclient\TestCase;
+use yiiunit\extensions\authclient\traits\OAuthDefaultReturnUrlTestTrait;
 
 /**
  * @group google
  */
 class GoogleTest extends TestCase
 {
+    use OAuthDefaultReturnUrlTestTrait;
+
     protected function setUp()
     {
         $config = [
@@ -40,5 +43,23 @@ class GoogleTest extends TestCase
         ]);
         $this->assertTrue($token instanceof OAuthToken);
         $this->assertNotEmpty($token->getToken());
+    }
+
+    protected function createClient()
+    {
+        return new Google();
+    }
+
+    /**
+     * Data provider for [[testDefaultReturnUrl]].
+     * @return array test data.
+     */
+    public function defaultReturnUrlDataProvider()
+    {
+        return [
+            'default'                => [['authclient' => 'google'], null, '/?authclient=google'],
+            'remove extra parameter' => [['authclient' => 'google', 'extra' => 'userid'], null, '/?authclient=google'],
+            'keep extra parameter'   => [['authclient' => 'google', 'extra' => 'userid'], ['authclient', 'extra'], '/?authclient=google&extra=userid'],
+        ];
     }
 }

--- a/tests/traits/OAuthDefaultReturnUrlTestTrait.php
+++ b/tests/traits/OAuthDefaultReturnUrlTestTrait.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace yiiunit\extensions\authclient\traits;
+
+use yii\authclient\BaseOAuth;
+
+trait OAuthDefaultReturnUrlTestTrait
+{
+    /**
+     * @return mixed
+     */
+    abstract protected function createClient();
+
+    /**
+     * Data provider for [[testDefaultReturnUrl]].
+     * @return array test data.
+     */
+    abstract public function defaultReturnUrlDataProvider();
+
+    /**
+     * @dataProvider defaultReturnUrlDataProvider
+     *
+     * @param $requestQueryParams
+     * @param $parametersToKeepInReturnUrl
+     * @param $expectedReturnUrl
+     */
+    public function testDefaultReturnUrl($requestQueryParams, $parametersToKeepInReturnUrl, $expectedReturnUrl)
+    {
+        $module = \Yii::createObject(\yii\base\Module::className(), ['module']);
+        $controller = \Yii::createObject(\yii\web\Controller::className(), ['default', $module]);
+        $app = $this->mockWebApplication([
+            'components' => [
+                'request' => [
+                    'queryParams' => $requestQueryParams,
+                ],
+                'urlManager' => [
+                    'enablePrettyUrl' => true,
+                    'showScriptName' => false,
+                    'rules' => [
+                        '/' => '/module/default',
+                    ],
+                ],
+            ],
+            'controller' => $controller,
+        ]);
+
+        /** @var BaseOAuth $oauthClient */
+        $oauthClient = $this->createClient();
+        if (!empty($parametersToKeepInReturnUrl)) {
+            $oauthClient->parametersToKeepInReturnUrl = $parametersToKeepInReturnUrl;
+        }
+
+        $this->assertEquals($expectedReturnUrl, $oauthClient->getReturnUrl());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  | #274, #245, #244 

Since this is the second time (to me), when production Google login stops working, then I twisted a bit on the default return url generation.

Instead of removing every unnecessary url parameters, I think we should allow to configure which parameters what we should keep in the url. This way is future proof, if new parameters appears in the url.