### PR TITLE
Add aleternative statestorage in cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 authclient extension Change Log
 2.2.6 under development
 -----------------------
 
-- no changes in this release.
+- Enh #205: Add alternative storage system based on cache component (marty-macfly, tunecino)
 
 
 2.2.5 November 05, 2019

--- a/src/CacheStateStorage.php
+++ b/src/CacheStateStorage.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\authclient;
+
+use Yii;
+use yii\authclient\StateStorageInterface;
+use yii\caching\Cache;
+use yii\base\Component;
+use yii\di\Instance;
+
+/**
+ * CacheStateStorage provides Auth client state storage based in cache component.
+ *
+ * @see StateStorageInterface
+ *
+ */
+class CacheStateStorage extends Component implements StateStorageInterface
+{
+    /**
+     * @var Cache|array|string cache object or the application component ID of the cache object to be used.
+     *
+     * After the CacheStateStorage object is created, if you want to change this property,
+     * you should only assign it with a cache object.
+     *
+     * If not set - application 'cache' component will be used, but only, if it is available (e.g. in web application),
+     * otherwise - no cache will be used and no data saving will be performed.
+     */
+    public $cache;
+    public $prefix = 'cacheStorage';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function init()
+    {
+        parent::init();
+
+        if ($this->cache === null) {
+            if (Yii::$app->has('cache')) {
+                $this->cache = Yii::$app->get('cache');
+            }
+        } else {
+            $this->cache = Instance::ensure($this->cache, Cache::class);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function set($key, $value)
+    {
+        if ($this->cache !== null) {
+            $this->cache->set($this->prefix . $key, $value);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get($key)
+    {
+        if ($this->cache !== null) {
+            return $this->cache->get($this->prefix . $key);
+        }
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function remove($key)
+    {
+        if ($this->cache !== null) {
+            $this->cache->delete($this->prefix . $key);
+        }
+        return true;
+    }
+}

--- a/src/CacheStateStorage.php
+++ b/src/CacheStateStorage.php
@@ -76,7 +76,7 @@ class CacheStateStorage extends Component implements StateStorageInterface
     public function remove($key)
     {
         if ($this->cache !== null) {
-            $this->cache->delete($this->prefix . $key);
+            return $this->cache->delete($this->prefix . $key);
         }
         return true;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #205 

I'm also using the cache state storage, I don't think it fixed the issue #205 but I think it can be a good add-on and reply to some use case (mine is using the authclient in CLI where session is not available) so instead of having each one our own implementation, I think it make more sense to have it directly in the extension, what do you think ?
