### PR TITLE
Fix missing information in documentation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     },
     "suggest": {
         "web-token/jwt-checker": "required for JWS, JWT or JWK related flows like OpenIDConnect",
+        "web-token/jwt-key-mgmt": "required for JWS, JWT or JWK related flows like OpenIDConnect",
         "web-token/jwt-signature": "required for JWS, JWT or JWK related flows like OpenIDConnect",
         "web-token/jwt-signature-algorithm-hmac": "required for JWS, JWT or JWK related flows like OpenIDConnect",
         "web-token/jwt-signature-algorithm-ecdsa": "required for JWS, JWT or JWK related flows like OpenIDConnect",

--- a/docs/guide-ja/open-id-connect.md
+++ b/docs/guide-ja/open-id-connect.md
@@ -29,20 +29,21 @@ OpenID 接続
 
 **注意!** 'OpenID 接続' プロトコルは、認証のプロセスをセキュアにするために、 [JWS](http://tools.ietf.org/html/draft-ietf-jose-json-web-signature) 検証を使います。
 そのような検証を使うためには。このエクステンションがデフォルトでは要求していない
-`web-token/jwt-checker`, `web-token/jwt-signature`, `web-token/jwt-signature-algorithm-hmac`, `web-token/jwt-signature-algorithm-ecdsa`, `web-token/jwt-signature-algorithm-rsa` ライブラリをインストールする必要があります。
+`web-token/jwt-checker`, `web-token/jwt-key-mgmt`, `web-token/jwt-signature`, `web-token/jwt-signature-algorithm-hmac`, `web-token/jwt-signature-algorithm-ecdsa`, `web-token/jwt-signature-algorithm-rsa` ライブラリをインストールする必要があります。
 
 ```
-composer require --prefer-dist "web-token/jwt-checker:~1.0" "web-token/jwt-signature:~1.0" "web-token/jwt-signature-algorithm-hmac:~1.0" "web-token/jwt-signature-algorithm-ecdsa:~1.0" "web-token/jwt-signature-algorithm-rsa:~1.0"
+composer require --prefer-dist "web-token/jwt-checker:>=1.0 <3.0" "web-token/jwt-signature:>=1.0 <3.0" "web-token/jwt-signature-algorithm-hmac:>=1.0 <3.0" "web-token/jwt-signature-algorithm-ecdsa:>=1.0 <3.0" "web-token/jwt-signature-algorithm-rsa:>=1.0 <3.0"
 ```
 
 または、
 
 ```json
-"web-token/jwt-checker": "~1.0",
-"web-token/jwt-signature": "~1.0",
-"web-token/jwt-signature-algorithm-hmac": "~1.0",
-"web-token/jwt-signature-algorithm-ecdsa": "~1.0",
-"web-token/jwt-signature-algorithm-rsa": "~1.0"
+"web-token/jwt-checker": ">=1.0 <3.0",
+"web-token/jwt-key-mgmt": ">=1.0  <3.0",
+"web-token/jwt-signature": "~1.0 <3.0",
+"web-token/jwt-signature-algorithm-hmac": "~1.0  <3.0",
+"web-token/jwt-signature-algorithm-ecdsa": "~1.0  <3.0",
+"web-token/jwt-signature-algorithm-rsa": "~1.0  <3.0"
 ```
 
 をあなたの composer.joson の`require` セクションに追加します。

--- a/docs/guide/open-id-connect.md
+++ b/docs/guide/open-id-connect.md
@@ -28,20 +28,21 @@ Application configuration example:
 Authentication workflow is exactly the same as for OAuth2.
 
 **Heads up!** 'OpenID Connect' protocol uses [JWS](http://tools.ietf.org/html/draft-ietf-jose-json-web-signature) verification
-for the authentication process securing. You will need to install `web-token/jwt-checker`, `web-token/jwt-signature`, `web-token/jwt-signature-algorithm-hmac`, `web-token/jwt-signature-algorithm-ecdsa` and `web-token/jwt-signature-algorithm-rsa` libraries in order to use such verification. These libraries are not required by this extension by default. It can be done via composer:
+for the authentication process securing. You will need to install `web-token/jwt-checker`, `web-token/jwt-key-mgmt`, `web-token/jwt-signature`, `web-token/jwt-signature-algorithm-hmac`, `web-token/jwt-signature-algorithm-ecdsa` and `web-token/jwt-signature-algorithm-rsa` libraries in order to use such verification. These libraries are not required by this extension by default. It can be done via composer:
 
 ```
-composer require --prefer-dist "web-token/jwt-checker:~1.0" "web-token/jwt-signature:~1.0" "web-token/jwt-signature-algorithm-hmac:~1.0" "web-token/jwt-signature-algorithm-ecdsa:~1.0" "web-token/jwt-signature-algorithm-rsa:~1.0"
+composer require --prefer-dist "web-token/jwt-checker:>=1.0 <3.0" "web-token/jwt-signature:>=1.0 <3.0" "web-token/jwt-signature-algorithm-hmac:>=1.0 <3.0" "web-token/jwt-signature-algorithm-ecdsa:>=1.0 <3.0" "web-token/jwt-signature-algorithm-rsa:>=1.0 <3.0"
 ```
 
 or add
 
 ```json
-"web-token/jwt-checker": "~1.0",
-"web-token/jwt-signature": "~1.0",
-"web-token/jwt-signature-algorithm-hmac": "~1.0",
-"web-token/jwt-signature-algorithm-ecdsa": "~1.0",
-"web-token/jwt-signature-algorithm-rsa": "~1.0"
+"web-token/jwt-checker": ">=1.0 <3.0",
+"web-token/jwt-key-mgmt": ">=1.0  <3.0",
+"web-token/jwt-signature": "~1.0 <3.0",
+"web-token/jwt-signature-algorithm-hmac": "~1.0  <3.0",
+"web-token/jwt-signature-algorithm-ecdsa": "~1.0  <3.0",
+"web-token/jwt-signature-algorithm-rsa": "~1.0  <3.0"
 ```
 
 to the `require` section of your composer.json.

--- a/src/OpenIdConnect.php
+++ b/src/OpenIdConnect.php
@@ -48,14 +48,14 @@ use yii\web\HttpException;
  * ]
  * ```
  *
- * This class requires `web-token/jwt-checker`, `web-token/jwt-signature`, `web-token/jwt-signature-algorithm-hmac`,
+ * This class requires `web-token/jwt-checker`,`web-token/jwt-key-mgmt`, `web-token/jwt-signature`, `web-token/jwt-signature-algorithm-hmac`,
  * `web-token/jwt-signature-algorithm-ecdsa` and `web-token/jwt-signature-algorithm-rsa` libraries to be installed for
  * JWS verification. This can be done via composer:
  *
  * ```
- * composer require --prefer-dist "web-token/jwt-checker:~1.0" "web-token/jwt-signature:~1.0"
- * "web-token/jwt-signature-algorithm-hmac:~1.0" "web-token/jwt-signature-algorithm-ecdsa:~1.0"
- * "web-token/jwt-signature-algorithm-rsa:~1.0"
+ * composer require --prefer-dist "web-token/jwt-checker:>=1.0 <3.0" "web-token/jwt-signature:>=1.0 <3.0"
+ * "web-token/jwt-signature:>=1.0 <3.0" "web-token/jwt-signature-algorithm-hmac:>=1.0 <3.0"
+ * "web-token/jwt-signature-algorithm-ecdsa:>=1.0 <3.0" "web-token/jwt-signature-algorithm-rsa:>=1.0 <3.0"
  * ```
  *
  * Note: if you are using well-trusted OpenIdConnect provider, you may disable [[validateJws]], making installation of
@@ -85,9 +85,9 @@ class OpenIdConnect extends OAuth2
     public $issuerUrl;
     /**
      * @var bool whether to validate/decrypt JWS received with Auth token.
-     * Note: this functionality requires `web-token/jwt-checker`, `web-token/jwt-signature` composer package to be installed.
-     * You can disable this option in case of usage of trusted OpenIDConnect provider, however this violates
-     * the protocol rules, so you are doing it on your own risk.
+     * Note: this functionality requires `web-token/jwt-checker`, `web-token/jwt-key-mgmt`, `web-token/jwt-signature`
+     * composer package to be installed. You can disable this option in case of usage of trusted OpenIDConnect provider,
+     * however this violates the protocol rules, so you are doing it on your own risk.
      */
     public $validateJws = true;
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 

Related to PR #285 there was a missing composer suggested dependency in `composer.json` and in the documentation and the version requirement was not accurate we can use version 1.x (compatible for php >= 7.1) or 2.x (compatible for php >= 7.3). Sorry for that I've should have seen it before.