### PR TITLE
applyAccessTokenToRequest tokenParamKey

### DIFF
--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -135,7 +135,7 @@ abstract class OAuth2 extends BaseOAuth
     public function applyAccessTokenToRequest($request, $accessToken)
     {
         $data = $request->getData();
-        $data['access_token'] = $accessToken->getToken();
+        $data[$accessToken->tokenParamKey] = $accessToken->getToken();
         $request->setData($data);
     }
 


### PR DESCRIPTION
applyAccessTokenToRequest tokenParamKey should be read from config

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 