### PR TITLE
Fix #309 `BaseOAuth->beforeApiRequestSend()` try to refresh token if `BaseOAuth->autoRefreshAccessToken = true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 authclient extension Change Log
 2.2.8 under development
 -----------------------
 
-- Bug #309: `BaseOAuth->beforeApiRequestSend()` try to refresh token if `BaseOAuth->autoRefreshAccessToken = true` instead of throwing directly 'Invalid access token.' exception (marty-macfly)
+- Bug #309: Try to refresh token in `BaseOAuth->beforeApiRequestSend()` if `BaseOAuth->autoRefreshAccessToken = true` instead of throwing "Invalid access token" exception (marty-macfly)
 
 
 2.2.7 February 12, 2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 authclient extension Change Log
 2.2.8 under development
 -----------------------
 
-- no changes in this release.
+- Bug #309: `BaseOAuth->beforeApiRequestSend()` try to refresh token if `BaseOAuth->autoRefreshAccessToken = true` instead of throwing directly 'Invalid access token.' exception (marty-macfly)
 
 
 2.2.7 February 12, 2020

--- a/src/BaseOAuth.php
+++ b/src/BaseOAuth.php
@@ -306,8 +306,10 @@ abstract class BaseOAuth extends BaseClient
     public function beforeApiRequestSend($event)
     {
         $accessToken = $this->getAccessToken();
-        if (!is_object($accessToken) || !$accessToken->getIsValid()) {
+        if (!is_object($accessToken) || (!$accessToken->getIsValid() && !$this->autoRefreshAccessToken)) {
             throw new Exception('Invalid access token.');
+        } else {
+            $accessToken = $this->refreshAccessToken($accessToken);
         }
 
         $this->applyAccessTokenToRequest($event->request, $accessToken);

--- a/tests/traits/OAuthDefaultReturnUrlTestTrait.php
+++ b/tests/traits/OAuthDefaultReturnUrlTestTrait.php
@@ -27,12 +27,18 @@ trait OAuthDefaultReturnUrlTestTrait
     public function testDefaultReturnUrl($requestQueryParams, $parametersToKeepInReturnUrl, $expectedReturnUrl)
     {
         $module = \Yii::createObject(\yii\base\Module::className(), ['module']);
-        $controller = \Yii::createObject(\yii\web\Controller::className(), ['default', $module]);
+        $request = \Yii::createObject([
+            'class' => \yii\web\Request::className(),
+            'queryParams' => $requestQueryParams
+        ]);
+        $controller = \Yii::createObject([
+            'class' => \yii\web\Controller::className(),
+            'request' => $request,
+            'response' => \yii\web\Response::className(),
+        ], ['default', $module]);
         $app = $this->mockWebApplication([
             'components' => [
-                'request' => [
-                    'queryParams' => $requestQueryParams,
-                ],
+                'request' => $request,
                 'urlManager' => [
                     'enablePrettyUrl' => true,
                     'showScriptName' => false,

--- a/tests/traits/OAuthDefaultReturnUrlTestTrait.php
+++ b/tests/traits/OAuthDefaultReturnUrlTestTrait.php
@@ -30,7 +30,6 @@ trait OAuthDefaultReturnUrlTestTrait
         $request = \Yii::createObject([
             'class' => \yii\web\Request::className(),
             'queryParams' => $requestQueryParams,
-            'hostInfo' => 'http://testdomain.com',
             'scriptUrl' => '/index.php',
         ]);
         $response = \Yii::createObject([

--- a/tests/traits/OAuthDefaultReturnUrlTestTrait.php
+++ b/tests/traits/OAuthDefaultReturnUrlTestTrait.php
@@ -29,12 +29,18 @@ trait OAuthDefaultReturnUrlTestTrait
         $module = \Yii::createObject(\yii\base\Module::className(), ['module']);
         $request = \Yii::createObject([
             'class' => \yii\web\Request::className(),
-            'queryParams' => $requestQueryParams
+            'queryParams' => $requestQueryParams,
+            'hostInfo' => 'http://testdomain.com',
+            'scriptUrl' => '/index.php',
+        ]);
+        $response = \Yii::createObject([
+            'class' => \yii\web\Response::className(),
+            'charset' => 'UTF-8',
         ]);
         $controller = \Yii::createObject([
             'class' => \yii\web\Controller::className(),
             'request' => $request,
-            'response' => \yii\web\Response::className(),
+            'response' => $response,
         ], ['default', $module]);
         $app = $this->mockWebApplication([
             'components' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #309 
