### PR TITLE
Fix method getCode is always zero in php Exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 authclient extension Change Log
 2.2.11 under development
 ------------------------
 
-- no changes in this release.
+- Enh #318: Add `statusCode` from response to init `InvalidResponseException` in `sendRequest` method of `yii\authclient\BaseOAuth` class
 
 
 2.2.10 May 05, 2021

--- a/src/BaseOAuth.php
+++ b/src/BaseOAuth.php
@@ -230,7 +230,11 @@ abstract class BaseOAuth extends BaseClient
         $response = $request->send();
 
         if (!$response->getIsOk()) {
-            throw new InvalidResponseException($response, 'Request failed with code: ' . $response->getStatusCode() . ', message: ' . $response->getContent());
+            throw new InvalidResponseException(
+                $response,
+                'Request failed with code: ' . $response->getStatusCode() . ', message: ' . $response->getContent(),
+                intval($response->statusCode)
+            );
         }
 
         return $response->getData();

--- a/src/BaseOAuth.php
+++ b/src/BaseOAuth.php
@@ -230,10 +230,11 @@ abstract class BaseOAuth extends BaseClient
         $response = $request->send();
 
         if (!$response->getIsOk()) {
+            $statusCode = $response->getStatusCode();
             throw new InvalidResponseException(
                 $response,
-                'Request failed with code: ' . $response->getStatusCode() . ', message: ' . $response->getContent(),
-                intval($response->statusCode)
+                'Request failed with code: ' . $statusCode . ', message: ' . $response->getContent(),
+                (int) $statusCode
             );
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

This method is used to send requests. But after receiving a response, they did not initial `InvalidResponseException `in the right way. It is missed the statusCode from the response that we need it to pass into `InvalidResponseException`, `yii\base\Exception` and `\Exception`
That's why the method `getCode()` from `\Exception` is always zero.