### PR TITLE
Use `random_int()` when generating OAuth1 nonce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Yii Framework 2 authclient extension Change Log
 ------------------------
 
 - Enh #318: Add `statusCode` from response to init `InvalidResponseException` in `sendRequest` method of `yii\authclient\BaseOAuth` class
-- Enh: Use `random_int()` when generating OAuth1 nonce (samdark)
+- Enh #327: Use `random_int()` when generating OAuth1 nonce (samdark)
 
 2.2.10 May 05, 2021
 -------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Yii Framework 2 authclient extension Change Log
 ------------------------
 
 - Enh #318: Add `statusCode` from response to init `InvalidResponseException` in `sendRequest` method of `yii\authclient\BaseOAuth` class
-
+- Enh: Use `random_int()` when generating OAuth1 nonce (samdark)
 
 2.2.10 May 05, 2021
 -------------------

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     ],
     "require": {
         "yiisoft/yii2": "~2.0.13",
-        "yiisoft/yii2-httpclient": "~2.0.5"
+        "yiisoft/yii2-httpclient": "~2.0.5",
+        "paragonie/random_compat": "^2.0"
     },
     "require-dev": {
         "cweagans/composer-patches": "^1.7",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "yiisoft/yii2": "~2.0.13",
         "yiisoft/yii2-httpclient": "~2.0.5",
-        "paragonie/random_compat": "^2.0"
+        "paragonie/random_compat": ">=1"
     },
     "require-dev": {
         "cweagans/composer-patches": "^1.7",

--- a/src/OAuth1.php
+++ b/src/OAuth1.php
@@ -252,7 +252,7 @@ abstract class OAuth1 extends BaseOAuth
      */
     protected function generateNonce()
     {
-        return md5(microtime() . mt_rand());
+        return md5(microtime() . random_int(0, PHP_INT_MAX));
     }
 
     /**

--- a/tests/TokenTest.php
+++ b/tests/TokenTest.php
@@ -67,7 +67,7 @@ class TokenTest extends TestCase
         $oauthToken->setTokenSecret($tokenSecret);
         $this->assertEquals($tokenSecret, $oauthToken->getTokenSecret(), 'Unable to setup token secret!');
 
-        $tokenExpireDuration = rand(1000, 2000);
+        $tokenExpireDuration = random_int(1000, 2000);
         $oauthToken->setExpireDuration($tokenExpireDuration);
         $this->assertEquals($tokenExpireDuration, $oauthToken->getExpireDuration(), 'Unable to setup expire duration!');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | related to https://github.com/yiisoft/yii2/pull/18817
