### PR TITLE
OpenID Connect `token_endpoint_auth_methods_supported` is optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 authclient extension Change Log
 2.2.12 under development
 ------------------------
 
-- no changes in this release.
+- Bug #330: OpenID Connect client now defaults to `'client_secret_basic'` in case `token_endpoint_auth_methods_supported` isn't specified.
 
 
 2.2.11 August 09, 2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 authclient extension Change Log
 2.2.12 under development
 ------------------------
 
-- Bug #330: OpenID Connect client now defaults to `'client_secret_basic'` in case `token_endpoint_auth_methods_supported` isn't specified.
+- Bug #330: OpenID Connect client now defaults to `'client_secret_basic'` in case `token_endpoint_auth_methods_supported` isn't specified (rhertogh)
 
 
 2.2.11 August 09, 2021

--- a/src/OpenIdConnect.php
+++ b/src/OpenIdConnect.php
@@ -209,12 +209,13 @@ class OpenIdConnect extends OAuth2
     /**
      * Returns particular configuration parameter value.
      * @param string $name configuration parameter name.
+     * @param mixed $default value to be returned if the configuration parameter isn't set.
      * @return mixed configuration parameter value.
      */
-    public function getConfigParam($name)
+    public function getConfigParam($name, $default = null)
     {
         $params = $this->getConfigParams();
-        return $params[$name];
+        return array_key_exists($name, $params) ? $params[$name] : $default;
     }
 
     /**
@@ -294,7 +295,7 @@ class OpenIdConnect extends OAuth2
      */
     protected function applyClientCredentialsToRequest($request)
     {
-        $supportedAuthMethods = $this->getConfigParam('token_endpoint_auth_methods_supported');
+        $supportedAuthMethods = $this->getConfigParam('token_endpoint_auth_methods_supported', 'client_secret_basic');
 
         if (in_array('client_secret_basic', $supportedAuthMethods)) {
             $request->addHeaders([

--- a/tests/OpenIdConnectTest.php
+++ b/tests/OpenIdConnectTest.php
@@ -32,6 +32,9 @@ class OpenIdConnectTest extends TestCase
         $this->assertTrue(isset($configParams['token_endpoint']));
 
         $this->assertEquals($configParams['token_endpoint'], $authClient->getConfigParam('token_endpoint'));
+
+        // Test default value for non existing
+        $this->assertEquals('default', $authClient->getConfigParam('non-existing', 'default'));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | -

According to https://openid.net/specs/openid-connect-discovery-1_0.html#rfc.section.3 the `token_endpoint_auth_methods_supported` is optional. This PR makes sure the OpenID Connect client uses the default value of `'client_secret_basic'` in case it isn't specified.
