### PR TITLE
Regenerate `nonce` when refreshing access token with OpenId Connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Yii Framework 2 authclient extension Change Log
 - Bug #330: OpenID Connect client now defaults to `'client_secret_basic'` in case `token_endpoint_auth_methods_supported` isn't specified (rhertogh)
 - Bug #331: OpenID Connect `aud` claim can either be a string or a list of strings (azmeuk)
 - Bug #332: OpenID Connect `aud` nonce is passed from the authentication request to the token request (azmeuk)
+- Bug #339: OpenID Connect client now regenerates a new `nonce` when refreshing the access token (rhertogh)
+
 
 2.2.11 August 09, 2021
 ----------------------

--- a/src/OpenIdConnect.php
+++ b/src/OpenIdConnect.php
@@ -269,6 +269,13 @@ class OpenIdConnect extends OAuth2
         if ($this->tokenUrl === null) {
             $this->tokenUrl = $this->getConfigParam('token_endpoint');
         }
+
+        if ($this->getValidateAuthNonce()) {
+            $nonce = $this->generateAuthNonce();
+            $this->setState('authNonce', $nonce);
+            $token->setParam('nonce', $nonce);
+        }
+
         return parent::refreshAccessToken($token);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

This PR resolves a bug when using `\yii\authclient\OpenIdConnect::refreshAccessToken()` when `\yii\authclient\OpenIdConnect::getValidateAuthNonce()` is `true` caused by the 'nonce' not being present in the 'state'. It also prevents re-using of the `nonce` from the original `$authCode` by creating a new one instead of using the existing one.
