### PR TITLE
Store `nonce` state when refreshing access token with OpenId Connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Yii Framework 2 authclient extension Change Log
 - Bug #330: OpenID Connect client now defaults to `'client_secret_basic'` in case `token_endpoint_auth_methods_supported` isn't specified (rhertogh)
 - Bug #331: OpenID Connect `aud` claim can either be a string or a list of strings (azmeuk)
 - Bug #332: OpenID Connect `aud` nonce is passed from the authentication request to the token request (azmeuk)
+- Bug #340: OpenID Connect client stores the access token `nonce` in the state upon refreshing it when `getValidateAuthNonce` is `true` (rhertogh)
+
 
 2.2.11 August 09, 2021
 ----------------------

--- a/src/OpenIdConnect.php
+++ b/src/OpenIdConnect.php
@@ -275,6 +275,11 @@ class OpenIdConnect extends OAuth2
         if ($this->tokenUrl === null) {
             $this->tokenUrl = $this->getConfigParam('token_endpoint');
         }
+
+        if ($this->getValidateAuthNonce() && !empty($token->getParam('nonce'))) {
+            $this->setState('authNonce', $token->getParam('nonce'));
+        }
+
         return parent::refreshAccessToken($token);
     }
 

--- a/src/OpenIdConnect.php
+++ b/src/OpenIdConnect.php
@@ -276,8 +276,9 @@ class OpenIdConnect extends OAuth2
             $this->tokenUrl = $this->getConfigParam('token_endpoint');
         }
 
-        if ($this->getValidateAuthNonce() && !empty($token->getParam('nonce'))) {
-            $this->setState('authNonce', $token->getParam('nonce'));
+        $nonce = $token->getParam('nonce');
+        if ($this->getValidateAuthNonce() && !empty($nonce)) {
+            $this->setState('authNonce', $nonce);
         }
 
         return parent::refreshAccessToken($token);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -
| Related to | #332 , #333 

This PR resolves a bug when using `\yii\authclient\OpenIdConnect::refreshAccessToken()` when `\yii\authclient\OpenIdConnect::getValidateAuthNonce()` is `true`.