### PR TITLE
Use `id_token` claim for getUserAttributes() if 'userinfo_endpoint' is not available.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Yii Framework 2 authclient extension Change Log
 - Bug #330: OpenID Connect client now defaults to `'client_secret_basic'` in case `token_endpoint_auth_methods_supported` isn't specified (rhertogh)
 - Bug #331: OpenID Connect `aud` claim can either be a string or a list of strings (azmeuk)
 - Bug #332: OpenID Connect `aud` nonce is passed from the authentication request to the token request (azmeuk)
+- Enh #341: OpenID Connect client now uses access token `'id_token'` claim for `getUserAttributes()` if `userinfo_endpoint` is not available (rhertogh)
+
 
 2.2.11 August 09, 2021
 ----------------------

--- a/src/OpenIdConnect.php
+++ b/src/OpenIdConnect.php
@@ -77,7 +77,7 @@ use yii\web\HttpException;
 class OpenIdConnect extends OAuth2
 {
     // https://openid.net/specs/openid-connect-core-1_0.html#rfc.section.2
-    const ID_TOKEN_CLAIMS = [
+    public $defaultIdTokenClaims = [
         'iss', // Issuer Identifier for the Issuer of the response.
         'sub', // Subject Identifier.
         'aud', // Audience(s) that this ID Token is intended for.
@@ -325,7 +325,7 @@ class OpenIdConnect extends OAuth2
             } else {
                 $idTokenClaims = Json::decode(StringHelper::base64UrlDecode(explode('.', $idToken)[1]));
             }
-            $metaDataFields = array_flip(self::ID_TOKEN_CLAIMS);
+            $metaDataFields = array_flip($this->defaultIdTokenClaims);
             unset($metaDataFields['sub']); // "Subject Identifier" is not meta data
             $idTokenData = array_diff_key($idTokenClaims, $metaDataFields);
         }

--- a/src/OpenIdConnect.php
+++ b/src/OpenIdConnect.php
@@ -76,7 +76,11 @@ use yii\web\HttpException;
  */
 class OpenIdConnect extends OAuth2
 {
-    // https://openid.net/specs/openid-connect-core-1_0.html#rfc.section.2
+    /**
+     * @var array Predefined OpenID Connect Claims
+     * @see https://openid.net/specs/openid-connect-core-1_0.html#rfc.section.2
+     * @since 2.2.12
+     */
     public $defaultIdTokenClaims = [
         'iss', // Issuer Identifier for the Issuer of the response.
         'sub', // Subject Identifier.
@@ -252,6 +256,7 @@ class OpenIdConnect extends OAuth2
      * Set the OpenID provider configuration manually, this will bypass the automatic discovery via
      * the /.well-known/openid-configuration endpoint.
      * @param array $configParams OpenID provider configuration parameters.
+     * @since 2.2.12
      */
     public function setConfigParams($configParams)
     {

--- a/src/OpenIdConnect.php
+++ b/src/OpenIdConnect.php
@@ -22,6 +22,7 @@ use yii\base\InvalidConfigException;
 use yii\caching\Cache;
 use yii\di\Instance;
 use yii\helpers\Json;
+use yii\helpers\StringHelper;
 use yii\web\HttpException;
 
 /**
@@ -75,6 +76,20 @@ use yii\web\HttpException;
  */
 class OpenIdConnect extends OAuth2
 {
+    // https://openid.net/specs/openid-connect-core-1_0.html#rfc.section.2
+    const ID_TOKEN_CLAIMS = [
+        'iss', // Issuer Identifier for the Issuer of the response.
+        'sub', // Subject Identifier.
+        'aud', // Audience(s) that this ID Token is intended for.
+        'exp', // Expiration time on or after which the ID Token MUST NOT be accepted for processing.
+        'iat', // Time at which the JWT was issued.
+        'auth_time', // Time when the End-User authentication occurred.
+        'nonce', // String value used to associate a Client session with an ID Token, and to mitigate replay attacks.
+        'acr', // Authentication Context Class Reference.
+        'amr', // Authentication Methods References.
+        'azp', // Authorized party - the party to which the ID Token was issued.
+    ];
+
     /**
      * {@inheritdoc}
      */
@@ -234,6 +249,16 @@ class OpenIdConnect extends OAuth2
     }
 
     /**
+     * Set the OpenID provider configuration manually, this will bypass the automatic discovery via
+     * the /.well-known/openid-configuration endpoint.
+     * @param array $configParams OpenID provider configuration parameters.
+     */
+    public function setConfigParams($configParams)
+    {
+        $this->_configParams = $configParams;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function buildAuthUrl(array $params = [])
@@ -283,7 +308,29 @@ class OpenIdConnect extends OAuth2
      */
     protected function initUserAttributes()
     {
-        return $this->api($this->getConfigParam('userinfo_endpoint'), 'GET');
+        // Use 'userinfo_endpoint' config if available,
+        // try to extract user claims from access token's 'id_token' claim otherwise.
+
+        $userinfoEndpoint = $this->getConfigParam('userinfo_endpoint');
+        if (!empty($userinfoEndpoint)) {
+            return $this->api($userinfoEndpoint, 'GET');
+        }
+
+        $token = $this->accessToken;
+        $idToken = $token->getParam('id_token');
+        $idTokenData = [];
+        if (!empty($idToken)) {
+            if ($this->validateJws) {
+                $idTokenClaims = $this->loadJws($idToken);
+            } else {
+                $idTokenClaims = Json::decode(StringHelper::base64UrlDecode(explode('.', $idToken)[1]));
+            }
+            $metaDataFields = array_flip(self::ID_TOKEN_CLAIMS);
+            unset($metaDataFields['sub']); // "Subject Identifier" is not meta data
+            $idTokenData = array_diff_key($idTokenClaims, $metaDataFields);
+        }
+
+        return $idTokenData;
     }
 
     /**

--- a/tests/OpenIdConnectTest.php
+++ b/tests/OpenIdConnectTest.php
@@ -2,6 +2,7 @@
 
 namespace yiiunit\extensions\authclient;
 
+use yii\authclient\OAuthToken;
 use yii\authclient\OpenIdConnect;
 use yii\caching\ArrayCache;
 
@@ -109,5 +110,25 @@ class OpenIdConnectTest extends TestCase
         $query = parse_url($builtAuthUrl)['query'];
         parse_str($query, $query_vars);
         $this->assertEquals($query_vars['nonce'], $nonce);
+    }
+
+    public function testUserInfoFromToken()
+    {
+        $accessToken = new OAuthToken([
+            'params' => [
+                'id_token' => 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJhdWQiOiJ0ZXN0LWNsaWVudC10eXBlLWF1dGgtY29kZS1vcGVuLWlkLWNvbm5lY3QiLCJpc3MiOiJodHRwczovL2xvY2FsaG9zdCIsImlhdCI6MTYzNTY5NDUzNi40MjkyMzcsImV4cCI6NDc5MTM2ODEzNiwic3ViIjoiMTIzIiwiYXV0aF90aW1lIjoxNjM1NjkwOTM1LCJub25jZSI6InNWbEVmS2xNMTdhYlJfY2Q5cXhvcU5fZHN3a0VRWXUxIn0.LgV-jFoopYnEhgygtt4bDL4HV1Rnw_cuKgopQ_I8f2YxDUlXKO2M0ANjA1iWIsBTCAKnI5JF7wYWBlK7eFJkU16U8yNVYHyUNaMGzXG1Q3khLmPfa9tmU2Kj2loA2hGGkZTjHCAuDgYSSFucLlFnqcR4-vhhwUyZdvFvwRRi0FF1r10m2oNmzfVLAcQxo2C5C_inSmuGnzfWqvrsDjdnT8N2XE2e3hVRxlIEv4GkupUejjdyWlSBjsUjnfXMlmi6VBn7HfElcVjJqp3L7GHVV1zfSA82e3oo7_wvQbb090M4nwFOmasvGnvZddELQdxL9KW0s_AIdkUM5lFxFFnl8Q',
+            ]
+        ]);
+
+        $authClient = new OpenIdConnect([
+            'cache' => null,
+            'configParams' => [],
+            'accessToken' => $accessToken,
+            'validateJws' => false,
+        ]);
+
+        $userAttributes = $authClient->getUserAttributes();
+
+        $this->assertEquals(['sub' => '123'], $userAttributes);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #240 