### PR TITLE
Support JWT in userinfo_endpoint response for OpenID Connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Yii Framework 2 authclient extension Change Log
 - Bug #332: OpenID Connect `aud` nonce is passed from the authentication request to the token request (azmeuk)
 - Bug #339: OpenID Connect client now regenerates a new `nonce` when refreshing the access token (rhertogh)
 - Enh #341: OpenID Connect client now uses access token `'id_token'` claim for `getUserAttributes()` if `userinfo_endpoint` is not available (rhertogh)
+- Enh #342: OpenID Connect client support for JWT in `userinfo_endpoint` response (rhertogh)
 
 
 2.2.11 August 09, 2021

--- a/src/BaseOAuth.php
+++ b/src/BaseOAuth.php
@@ -238,7 +238,11 @@ abstract class BaseOAuth extends BaseClient
             );
         }
 
-        return $response->getData();
+        if (stripos($response->headers->get('content-type'), 'application/jwt') !== false) {
+            return $response->getContent();
+        } else {
+            return $response->getData();
+        }
     }
 
     /**

--- a/src/OpenIdConnect.php
+++ b/src/OpenIdConnect.php
@@ -21,6 +21,7 @@ use yii\authclient\signature\HmacSha;
 use yii\base\InvalidConfigException;
 use yii\caching\Cache;
 use yii\di\Instance;
+use yii\helpers\ArrayHelper;
 use yii\helpers\Json;
 use yii\helpers\StringHelper;
 use yii\web\HttpException;
@@ -325,11 +326,19 @@ class OpenIdConnect extends OAuth2
 
         $userinfoEndpoint = $this->getConfigParam('userinfo_endpoint');
         if (!empty($userinfoEndpoint)) {
-            return $this->api($userinfoEndpoint, 'GET');
+            $userInfo = $this->api($userinfoEndpoint, 'GET');
+            // The userinfo endpoint can return a JSON object (which will be converted to an array) or a JWT.
+            if (is_array($userInfo)) {
+                return $userInfo;
+            } else {
+                // Use the userInfo endpoint as id_token and parse it as JWT below
+                $idToken = $userInfo;
+            }
+        } else {
+            $accessToken = $this->accessToken;
+            $idToken = $accessToken->getParam('id_token');
         }
 
-        $token = $this->accessToken;
-        $idToken = $token->getParam('id_token');
         $idTokenData = [];
         if (!empty($idToken)) {
             if ($this->validateJws) {

--- a/src/OpenIdConnect.php
+++ b/src/OpenIdConnect.php
@@ -68,7 +68,7 @@ use yii\web\HttpException;
  *
  * @property Cache|null $cache The cache object, `null` - if not enabled. Note that the type of this property
  * differs in getter and setter. See [[getCache()]] and [[setCache()]] for details.
- * @property-read array $configParams OpenID provider configuration parameters. This property is read-only.
+ * @property array $configParams OpenID provider configuration parameters.
  * @property bool $validateAuthNonce Whether to use and validate auth 'nonce' parameter in authentication
  * flow.
  *

--- a/src/OpenIdConnect.php
+++ b/src/OpenIdConnect.php
@@ -21,7 +21,6 @@ use yii\authclient\signature\HmacSha;
 use yii\base\InvalidConfigException;
 use yii\caching\Cache;
 use yii\di\Instance;
-use yii\helpers\ArrayHelper;
 use yii\helpers\Json;
 use yii\helpers\StringHelper;
 use yii\web\HttpException;

--- a/tests/OpenIdConnectTest.php
+++ b/tests/OpenIdConnectTest.php
@@ -131,4 +131,26 @@ class OpenIdConnectTest extends TestCase
 
         $this->assertEquals(['sub' => '123'], $userAttributes);
     }
+
+    public function testUserInfoFromUserInfoTokenResponse()
+    {
+        /** @var OpenIdConnect $oidcClient */
+        $oidcClient = $this->getMockBuilder(OpenIdConnect::className())
+            ->setMethods(['api'])
+            ->getMock();
+
+        $oidcClient->expects($this->once())
+            ->method('api')
+            ->willReturn(
+                'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJhdWQiOiJ0ZXN0LWNsaWVudC10eXBlLWF1dGgtY29kZS1vcGVuLWlkLWNvbm5lY3QiLCJpc3MiOiJodHRwczovL2xvY2FsaG9zdCIsImlhdCI6MTYzNTY5NDUzNi40MjkyMzcsImV4cCI6NDc5MTM2ODEzNiwic3ViIjoiMTIzIiwiYXV0aF90aW1lIjoxNjM1NjkwOTM1LCJub25jZSI6InNWbEVmS2xNMTdhYlJfY2Q5cXhvcU5fZHN3a0VRWXUxIn0.LgV-jFoopYnEhgygtt4bDL4HV1Rnw_cuKgopQ_I8f2YxDUlXKO2M0ANjA1iWIsBTCAKnI5JF7wYWBlK7eFJkU16U8yNVYHyUNaMGzXG1Q3khLmPfa9tmU2Kj2loA2hGGkZTjHCAuDgYSSFucLlFnqcR4-vhhwUyZdvFvwRRi0FF1r10m2oNmzfVLAcQxo2C5C_inSmuGnzfWqvrsDjdnT8N2XE2e3hVRxlIEv4GkupUejjdyWlSBjsUjnfXMlmi6VBn7HfElcVjJqp3L7GHVV1zfSA82e3oo7_wvQbb090M4nwFOmasvGnvZddELQdxL9KW0s_AIdkUM5lFxFFnl8Q'
+            );
+
+        $oidcClient->cache = null;
+        $oidcClient->configParams = ['userinfo_endpoint' => 'http://localhost'];
+        $oidcClient->validateJws = false;
+
+        $userAttributes = $oidcClient->getUserAttributes();
+
+        $this->assertEquals(['sub' => '123'], $userAttributes);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -

Some server can return a JWT in the Userinfo Response:
https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse
> If the UserInfo Response is signed and/or encrypted, then the Claims are returned in a JWT and the content-type MUST be `application/jwt`