### PR TITLE
Facebook OAuth 400 error when latin characters are used in App name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Yii Framework 2 authclient extension Change Log
 - Bug #339: OpenID Connect client now regenerates a new `nonce` when refreshing the access token (rhertogh)
 - Enh #341: OpenID Connect client now uses access token `'id_token'` claim for `getUserAttributes()` if `userinfo_endpoint` is not available (rhertogh)
 - Enh #342: OpenID Connect client support for JWT in `userinfo_endpoint` response (rhertogh)
-- BUG #344: Fix Facebook OAuth 400 error when latin characters are used in App name (pawelkania)
+- Bug #344: Fix Facebook OAuth 400 error when latin characters are used in App name (pawelkania)
 
 
 2.2.11 August 09, 2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,13 @@ Yii Framework 2 authclient extension Change Log
 
 2.2.12 under development
 ------------------------
-
 - Bug #330: OpenID Connect client now defaults to `'client_secret_basic'` in case `token_endpoint_auth_methods_supported` isn't specified (rhertogh)
 - Bug #331: OpenID Connect `aud` claim can either be a string or a list of strings (azmeuk)
 - Bug #332: OpenID Connect `aud` nonce is passed from the authentication request to the token request (azmeuk)
 - Bug #339: OpenID Connect client now regenerates a new `nonce` when refreshing the access token (rhertogh)
 - Enh #341: OpenID Connect client now uses access token `'id_token'` claim for `getUserAttributes()` if `userinfo_endpoint` is not available (rhertogh)
 - Enh #342: OpenID Connect client support for JWT in `userinfo_endpoint` response (rhertogh)
+- BUG #344: Fix Facebook OAuth 400 error when latin characters are used in App name (pawelkania)
 
 
 2.2.11 August 09, 2021

--- a/src/BaseOAuth.php
+++ b/src/BaseOAuth.php
@@ -10,6 +10,7 @@ namespace yii\authclient;
 use yii\base\Exception;
 use yii\base\InvalidArgumentException;
 use Yii;
+use yii\helpers\Inflector;
 use yii\httpclient\Request;
 
 /**
@@ -187,7 +188,7 @@ abstract class BaseOAuth extends BaseClient
     protected function defaultRequestOptions()
     {
         return [
-            'userAgent' => Yii::$app->name . ' OAuth ' . $this->version . ' Client',
+            'userAgent' => Inflector::slug(Yii::$app->name) . ' OAuth ' . $this->version . ' Client',
             'timeout' => 30,
         ];
     }


### PR DESCRIPTION
Facebook is throwing 400 Error when userAgent has latin characters (e.g. "ż").

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fix issue   | #345
