### PR TITLE
Add jwt-key-mgmt to the composer require cli example

### DIFF
--- a/docs/guide/open-id-connect.md
+++ b/docs/guide/open-id-connect.md
@@ -31,7 +31,7 @@ Authentication workflow is exactly the same as for OAuth2.
 for the authentication process securing. You will need to install `web-token/jwt-checker`, `web-token/jwt-key-mgmt`, `web-token/jwt-signature`, `web-token/jwt-signature-algorithm-hmac`, `web-token/jwt-signature-algorithm-ecdsa` and `web-token/jwt-signature-algorithm-rsa` libraries in order to use such verification. These libraries are not required by this extension by default. It can be done via composer:
 
 ```
-composer require --prefer-dist "web-token/jwt-checker:>=1.0 <3.0" "web-token/jwt-signature:>=1.0 <3.0" "web-token/jwt-signature-algorithm-hmac:>=1.0 <3.0" "web-token/jwt-signature-algorithm-ecdsa:>=1.0 <3.0" "web-token/jwt-signature-algorithm-rsa:>=1.0 <3.0"
+composer require --prefer-dist "web-token/jwt-checker:>=1.0 <3.0" "jwt-key-mgmt:>=1.0 <3.0" "web-token/jwt-signature:>=1.0 <3.0" "web-token/jwt-signature-algorithm-hmac:>=1.0 <3.0" "web-token/jwt-signature-algorithm-ecdsa:>=1.0 <3.0" "web-token/jwt-signature-algorithm-rsa:>=1.0 <3.0"
 ```
 
 or add


### PR DESCRIPTION
jwt-key-mgmt exists in the json example but is missing for the cli example

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  |❌
| Breaks BC?    |❌
| Fixed issues  | 
