### PR TITLE
Fixes #351: Unable to set TokenParamKey in OAuth2 config, gets hard overwritten in OAuth2::createToken()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 authclient extension Change Log
 2.2.14 under development
 ------------------------
 
-- no changes in this release.
+- Bug #351: Unable to set TokenParamKey in OAuth2 config, gets hard overwritten in OAuth2::createToken()
 
 
 2.2.13 September 04, 2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 authclient extension Change Log
 2.2.14 under development
 ------------------------
 
-- Bug #351: Unable to set TokenParamKey in OAuth2 config, gets hard overwritten in OAuth2::createToken()
+- Bug #351: Unable to set TokenParamKey in OAuth2 config, gets hard overwritten in OAuth2::createToken() (DSTester)
 
 
 2.2.13 September 04, 2022

--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -226,9 +226,8 @@ abstract class OAuth2 extends BaseOAuth
      */
     protected function createToken(array $tokenConfig = [])
     {
-        if(!isset($tokenConfig['tokenParamKey']) || empty($tokenConfig['tokenParamKey'])){
-            $tokenConfig['tokenParamKey'] = 'access_token';
-        }
+        $defaultTokenConfig = ['tokenParamKey' => 'access_token'];
+        $tokenConfig = array_merge($defaultTokenConfig, $tokenConfig);
 
         return parent::createToken($tokenConfig);
     }

--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -226,7 +226,9 @@ abstract class OAuth2 extends BaseOAuth
      */
     protected function createToken(array $tokenConfig = [])
     {
-        $tokenConfig['tokenParamKey'] = 'access_token';
+        if(!isset($tokenConfig['tokenParamKey']) || empty($tokenConfig['tokenParamKey'])){
+            $tokenConfig['tokenParamKey'] = 'access_token';
+        }
 
         return parent::createToken($tokenConfig);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #351
