### PR TITLE
fix: use issuer URL from openid configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 Yii Framework 2 authclient extension Change Log
 ===============================================
 
-2.2.15 under development
+2.2.15 July 13, 2023
 ------------------------
 
-- no changes in this release.
+- Bug #364: Use issuer claim from OpenID Configuration
 
 
 2.2.14 November 18, 2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Yii Framework 2 authclient extension Change Log
 ===============================================
 
-2.2.15 July 13, 2023
+2.2.15 under development
 ------------------------
 
 - Bug #364: Use issuer claim from OpenID Configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 authclient extension Change Log
 2.2.15 under development
 ------------------------
 
-- Bug #364: Use issuer claim from OpenID Configuration
+- Bug #364: Use issuer claim from OpenID Configuration (radwouters)
 
 
 2.2.14 November 18, 2022

--- a/src/OpenIdConnect.php
+++ b/src/OpenIdConnect.php
@@ -512,7 +512,8 @@ class OpenIdConnect extends OAuth2
      */
     protected function validateClaims(array $claims)
     {
-        if (!isset($claims['iss']) || (strcmp(rtrim($claims['iss'], '/'), rtrim($this->issuerUrl, '/')) !== 0)) {
+        $expectedIssuer = $this->getConfigParam('issuer', $this->issuerUrl);
+        if (!isset($claims['iss']) || (strcmp(rtrim($claims['iss'], '/'), rtrim($expectedIssuer, '/')) !== 0)) {
             throw new HttpException(400, 'Invalid "iss"');
         }
         if (!isset($claims['aud'])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #364 

Instead of using the issuer URL from $this->issueUrl, we now get it from the openid configuration. 