### PR TITLE
Fix registration of jQuery plugin

### DIFF
--- a/src/assets/authchoice.js
+++ b/src/assets/authchoice.js
@@ -9,7 +9,7 @@
  * @author Paul Klimov <klimov.paul@gmail.com>
  * @since 2.0
  */
-jQuery(function($) {
+(function ($) {
     $.fn.authchoice = function(options) {
         options = $.extend({
             triggerSelector: 'a.auth-link',
@@ -68,4 +68,4 @@ jQuery(function($) {
             });
         });
     };
-});
+})(window.jQuery);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 

I am not really sure if it's a bugfix, but I have experienced very weird behavior in some edge case scenario that led me here. The thing is that there's no need to wait for DOM ready event to register the plugin.