### PR TITLE
Added ClientErrorResponseException for 4xx response codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 authclient extension Change Log
 2.2.15 under development
 ------------------------
 
-- no changes in this release.
+- Enh: #367: Throw more specific `ClientErrorResponseException` when the response code in `BaseOAuth::sendRequest()` is a 4xx (rhertogh)  
 
 
 2.2.14 November 18, 2022

--- a/src/ClientErrorResponseException.php
+++ b/src/ClientErrorResponseException.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yii\authclient;
+
+/**
+ * ClientErrorResponseException represents an exception caused by a "client error" server response status code (4xx).
+ *
+ * @since 2.2.15
+ */
+class ClientErrorResponseException extends InvalidResponseException
+{
+}

--- a/src/InvalidResponseException.php
+++ b/src/InvalidResponseException.php
@@ -10,10 +10,11 @@ namespace yii\authclient;
 use yii\base\Exception;
 
 /**
- * InvalidResponseException represents an exception caused by invalid remote server response.
+ * InvalidResponseException represents an exception caused by a non-successful server response status code.
  *
  * @author Paul Klimov <klimov.paul@gmail.com>
  * @since 2.0
+ * @see \yii\httpclient\Response::getIsOk()
  */
 class InvalidResponseException extends Exception
 {

--- a/src/clients/VKontakte.php
+++ b/src/clients/VKontakte.php
@@ -7,7 +7,6 @@
 
 namespace yii\authclient\clients;
 
-use yii\authclient\InvalidResponseException;
 use yii\authclient\OAuth2;
 use yii\helpers\Json;
 

--- a/tests/OpenIdConnectTest.php
+++ b/tests/OpenIdConnectTest.php
@@ -60,7 +60,7 @@ class OpenIdConnectTest extends TestCase
         $this->assertEquals($cachedConfigParams, $authClient->getConfigParams());
 
         $authClient = new OpenIdConnect([
-            'issuerUrl' => 'https://invalid-url.com',
+            'issuerUrl' => 'https://yiiframework.com', // Should be a domain that returns an error for the /.well-known/openid-configuration endpoint
             'id' => 'foo',
             'cache' => $cache,
         ]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -

This PR allows to filter out client error response codes (4xx). E.g.

```php
try {
    $client->api('https://test');
} catch (ClientErrorResponseException $e) {
    // Handle client error response
}
```
