### PR TITLE
Fix deprecated exception in collection component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 authclient extension Change Log
 2.2.16 under development
 ------------------------
 
-- no changes in this release.
+- Enh #387: Use appropriate exception if client does not exist (eluhr)
 
 
 2.2.15 December 16, 2023

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -8,7 +8,7 @@
 namespace yii\authclient;
 
 use yii\base\Component;
-use yii\base\InvalidParamException;
+use yii\base\InvalidArgumentException;
 use Yii;
 
 /**
@@ -81,12 +81,12 @@ class Collection extends Component
     /**
      * @param string $id service id.
      * @return ClientInterface auth client instance.
-     * @throws InvalidParamException on non existing client request.
+     * @throws InvalidArgumentException on non existing client request.
      */
     public function getClient($id)
     {
         if (!array_key_exists($id, $this->_clients)) {
-            throw new InvalidParamException("Unknown auth client '{$id}'.");
+            throw new InvalidArgumentException("Unknown auth client '{$id}'.");
         }
         if (!is_object($this->_clients[$id])) {
             $this->_clients[$id] = $this->createClient($id, $this->_clients[$id]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

The [deprecated exception](https://github.com/yiisoft/yii2/blob/master/framework/base/InvalidParamException.php#L16) has been replaced with the appropriate one, ensuring backward compatibility since the [new exception derives from the old one](https://github.com/yiisoft/yii2/blob/master/framework/base/InvalidArgumentException.php#L17).
