### PR TITLE
Added support to configure the Oauth2 access token location in requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Yii Framework 2 authclient extension Change Log
 ------------------------
 
 - Enh #387: Use appropriate exception if client does not exist (eluhr)
-- Enh #388: Added support to configure the Oauth2 access token location in requests and added a generic Oauth2 client (rhertogh)
+- Enh #388: Added support to configure the OAuth2 access token location in requests and added a generic OAuth2 client (rhertogh)
 
 
 2.2.15 December 16, 2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 authclient extension Change Log
 ------------------------
 
 - Enh #387: Use appropriate exception if client does not exist (eluhr)
+- Enh #388: Added support to configure the Oauth2 access token location in requests and added a generic Oauth2 client (rhertogh)
 
 
 2.2.15 December 16, 2023

--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -86,8 +86,8 @@ abstract class OAuth2 extends BaseOAuth
 
     /**
      * @var string The location of the access token when it is applied to the request.
-     * NOTE: According to the OAuth2 specification this should be de `header` by default,
-     *       however, for Backwards compatibility the default value used here is `body`.
+     * NOTE: According to the OAuth2 specification this should be `header` by default,
+     *       however, for backwards compatibility the default value used here is `body`.
      * @since 2.2.16
      *
      * @see https://datatracker.ietf.org/doc/html/rfc6749#section-7
@@ -193,14 +193,17 @@ abstract class OAuth2 extends BaseOAuth
      */
     public function applyAccessTokenToRequest($request, $accessToken)
     {
-        if ($this->accessTokenLocation === self::ACCESS_TOKEN_LOCATION_BODY) {
-            $data = $request->getData();
-            $data['access_token'] = $accessToken->getToken();
-            $request->setData($data);
-        } elseif ($this->accessTokenLocation === self::ACCESS_TOKEN_LOCATION_HEADER) {
-            $request->getHeaders()->set('Authorization', 'Bearer ' . $accessToken->getToken());
-        } else {
-            throw new InvalidConfigException('Unknown access token location: ' . $this->accessTokenLocation);
+        switch($this->accessTokenLocation) {
+            case self::ACCESS_TOKEN_LOCATION_BODY:
+                $data = $request->getData();
+                $data['access_token'] = $accessToken->getToken();
+                $request->setData($data);
+                break;
+            case self::ACCESS_TOKEN_LOCATION_HEADER:
+                $request->getHeaders()->set('Authorization', 'Bearer ' . $accessToken->getToken());
+                break;
+            default:
+                throw new InvalidConfigException('Unknown access token location: ' . $this->accessTokenLocation);
         }
     }
 

--- a/src/OpenIdConnect.php
+++ b/src/OpenIdConnect.php
@@ -7,9 +7,9 @@
 
 namespace yii\authclient;
 
-use Jose\Component\Core\AlgorithmManager;
 use Jose\Component\Checker\AlgorithmChecker;
 use Jose\Component\Checker\HeaderCheckerManager;
+use Jose\Component\Core\AlgorithmManager;
 use Jose\Component\KeyManagement\JWKFactory;
 use Jose\Component\Signature\JWSLoader;
 use Jose\Component\Signature\JWSTokenSupport;
@@ -76,6 +76,11 @@ use yii\web\HttpException;
  */
 class OpenIdConnect extends OAuth2
 {
+    /**
+     * {@inheritdoc}
+     */
+    public $accessTokenLocation = OAuth2::ACCESS_TOKEN_LOCATION_HEADER;
+
     /**
      * @var array Predefined OpenID Connect Claims
      * @see https://openid.net/specs/openid-connect-core-1_0.html#rfc.section.2
@@ -350,15 +355,6 @@ class OpenIdConnect extends OAuth2
         }
 
         return $idTokenData;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function applyAccessTokenToRequest($request, $accessToken)
-    {
-        // OpenID Connect requires bearer token auth for the user info endpoint
-        $request->getHeaders()->set('Authorization', 'Bearer ' . $accessToken->getToken());
     }
 
     /**

--- a/src/clients/GitHub.php
+++ b/src/clients/GitHub.php
@@ -43,6 +43,11 @@ class GitHub extends OAuth2
     /**
      * {@inheritdoc}
      */
+    public $accessTokenLocation = OAuth2::ACCESS_TOKEN_LOCATION_HEADER;
+
+    /**
+     * {@inheritdoc}
+     */
     public $authUrl = 'https://github.com/login/oauth/authorize';
     /**
      * {@inheritdoc}

--- a/src/clients/Oauth2Client.php
+++ b/src/clients/Oauth2Client.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yii\authclient\clients;
+
+use yii\authclient\OAuth2;
+
+/**
+ * Generic client that allows authentication via OAuth 2.0.
+ *
+ * Example application configuration:
+ *
+ * ```php
+ * 'components' => [
+ *     'authClientCollection' => [
+ *         'class' => 'yii\authclient\Collection',
+ *         'clients' => [
+ *             'oauth2' => [
+ *                 'class' => 'yii\authclient\clients\Oauth2Client',
+ *                 'authUrl' => 'https://oauth2service.com/oauth2/authorize',
+ *                 'tokenUrl' => 'https://oauth2service.com/oauth2/authorize',
+ *                 'apiBaseUrl' => 'https://oauth2service.com/api',
+ *                 'clientId' => 'your_app_client_id',
+ *                 'clientSecret' => 'your_app_client_secret',
+ *                 'name' => 'custom name',
+ *                 'title' => 'custom title'
+ *             ],
+ *         ],
+ *     ]
+ *     // ...
+ * ]
+ * ```
+ *
+ * @since 2.2.16
+ */
+class Oauth2Client extends OAuth2
+{
+
+    /**
+     * {@inheritdoc}
+     */
+    public $accessTokenLocation = self::ACCESS_TOKEN_LOCATION_HEADER;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function initUserAttributes()
+    {
+        return []; // Plain Oauth 2.0 doesn't specify user attributes.
+    }
+}

--- a/src/clients/TwitterOAuth2.php
+++ b/src/clients/TwitterOAuth2.php
@@ -30,6 +30,11 @@ class TwitterOAuth2 extends OAuth2
     /**
      * {@inheritdoc}
      */
+    public $accessTokenLocation = OAuth2::ACCESS_TOKEN_LOCATION_HEADER;
+
+    /**
+     * {@inheritdoc}
+     */
     public $authUrl = 'https://api.twitter.com/oauth2/authenticate';
     /**
      * {@inheritdoc}
@@ -63,13 +68,5 @@ class TwitterOAuth2 extends OAuth2
     protected function defaultTitle()
     {
         return 'Twitter';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function applyAccessTokenToRequest($request, $accessToken)
-    {
-        $request->getHeaders()->set('Authorization', 'Bearer '. $accessToken->getToken());
     }
 }

--- a/tests/clients/FacebookTest.php
+++ b/tests/clients/FacebookTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace yiiunit\extensions\authclient\clients;
+
+use yii\authclient\clients\Facebook;
+use yii\authclient\OAuth2;
+use yiiunit\extensions\authclient\clients\base\BaseOauth2ClientTestCase;
+
+class FacebookTest extends BaseOauth2ClientTestCase
+{
+    protected function createClient()
+    {
+        return new Facebook();
+    }
+
+    protected function getExpectedTokenLocation()
+    {
+        return OAuth2::ACCESS_TOKEN_LOCATION_BODY;
+    }
+}

--- a/tests/clients/GitHubTest.php
+++ b/tests/clients/GitHubTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace yiiunit\extensions\authclient\clients;
+
+use yii\authclient\clients\GitHub;
+use yii\authclient\OAuth2;
+use yiiunit\extensions\authclient\clients\base\BaseOauth2ClientTestCase;
+
+class GitHubTest extends BaseOauth2ClientTestCase
+{
+    protected function createClient()
+    {
+        return new GitHub();
+    }
+
+    protected function getExpectedTokenLocation()
+    {
+        return OAuth2::ACCESS_TOKEN_LOCATION_HEADER;
+    }
+
+    protected function getAccessTokenHeaderTypeName()
+    {
+        return 'token';
+    }
+}

--- a/tests/clients/GoogleHybridTest.php
+++ b/tests/clients/GoogleHybridTest.php
@@ -3,16 +3,22 @@
 namespace yiiunit\extensions\authclient\clients;
 
 use yii\authclient\clients\GoogleHybrid;
-use yiiunit\extensions\authclient\TestCase;
+use yii\authclient\OAuth2;
+use yiiunit\extensions\authclient\clients\base\BaseOauth2ClientTestCase;
 use yiiunit\extensions\authclient\traits\OAuthDefaultReturnUrlTestTrait;
 
-class GoogleHybridTest extends TestCase
+class GoogleHybridTest extends BaseOauth2ClientTestCase
 {
     use OAuthDefaultReturnUrlTestTrait;
 
     protected function createClient()
     {
         return new GoogleHybrid();
+    }
+
+    protected function getExpectedTokenLocation()
+    {
+        return OAuth2::ACCESS_TOKEN_LOCATION_BODY;
     }
 
     /**

--- a/tests/clients/GoogleTest.php
+++ b/tests/clients/GoogleTest.php
@@ -3,29 +3,27 @@
 namespace yiiunit\extensions\authclient\clients;
 
 use yii\authclient\clients\Google;
+use yii\authclient\OAuth2;
 use yii\authclient\OAuthToken;
 use yii\authclient\signature\RsaSha;
-use yiiunit\extensions\authclient\TestCase;
+use yiiunit\extensions\authclient\clients\base\BaseOauth2ClientTestCase;
 use yiiunit\extensions\authclient\traits\OAuthDefaultReturnUrlTestTrait;
 
 /**
  * @group google
  */
-class GoogleTest extends TestCase
+class GoogleTest extends BaseOauth2ClientTestCase
 {
     use OAuthDefaultReturnUrlTestTrait;
 
-    protected function setUp()
+    protected function createClient()
     {
-        $config = [
-            'components' => [
-                'request' => [
-                    'hostInfo' => 'http://testdomain.com',
-                    'scriptUrl' => '/index.php',
-                ],
-            ]
-        ];
-        $this->mockApplication($config, '\yii\web\Application');
+        return new Google();
+    }
+
+    protected function getExpectedTokenLocation()
+    {
+        return OAuth2::ACCESS_TOKEN_LOCATION_BODY;
     }
 
     public function testAuthenticateUserJwt()
@@ -43,11 +41,6 @@ class GoogleTest extends TestCase
         ]);
         $this->assertTrue($token instanceof OAuthToken);
         $this->assertNotEmpty($token->getToken());
-    }
-
-    protected function createClient()
-    {
-        return new Google();
     }
 
     /**

--- a/tests/clients/LinkedInTest.php
+++ b/tests/clients/LinkedInTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace yiiunit\extensions\authclient\clients;
+
+use yii\authclient\clients\LinkedIn;
+use yii\authclient\OAuth2;
+use yiiunit\extensions\authclient\clients\base\BaseOauth2ClientTestCase;
+
+class LinkedInTest extends BaseOauth2ClientTestCase
+{
+    protected function createClient()
+    {
+        return new LinkedIn();
+    }
+
+    protected function getExpectedTokenLocation()
+    {
+        return OAuth2::ACCESS_TOKEN_LOCATION_BODY;
+    }
+
+    protected function getAccessTokenBodyParamName()
+    {
+        return 'oauth2_access_token';
+    }
+}

--- a/tests/clients/LiveTest.php
+++ b/tests/clients/LiveTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace yiiunit\extensions\authclient\clients;
+
+use yii\authclient\clients\Live;
+use yii\authclient\OAuth2;
+use yiiunit\extensions\authclient\clients\base\BaseOauth2ClientTestCase;
+
+class LiveTest extends BaseOauth2ClientTestCase
+{
+    protected function createClient()
+    {
+        return new Live();
+    }
+
+    protected function getExpectedTokenLocation()
+    {
+        return OAuth2::ACCESS_TOKEN_LOCATION_BODY;
+    }
+}

--- a/tests/clients/Oauth2ClientTest.php
+++ b/tests/clients/Oauth2ClientTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace yiiunit\extensions\authclient\clients;
+
+use yii\authclient\clients\Oauth2Client;
+use yii\authclient\OAuth2;
+use yiiunit\extensions\authclient\clients\base\BaseOauth2ClientTestCase;
+
+class Oauth2ClientTest extends BaseOauth2ClientTestCase
+{
+    protected function createClient()
+    {
+        return new Oauth2Client();
+    }
+
+    protected function getExpectedTokenLocation()
+    {
+        return OAuth2::ACCESS_TOKEN_LOCATION_HEADER;
+    }
+}

--- a/tests/clients/OpenIdConnectTest.php
+++ b/tests/clients/OpenIdConnectTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace yiiunit\extensions\authclient\clients;
+
+use yii\authclient\OAuth2;
+use yii\authclient\OpenIdConnect;
+use yiiunit\extensions\authclient\clients\base\BaseOauth2ClientTestCase;
+
+class OpenIdConnectTest extends BaseOauth2ClientTestCase
+{
+    protected function createClient()
+    {
+        return new OpenIdConnect();
+    }
+
+    protected function getExpectedTokenLocation()
+    {
+        return OAuth2::ACCESS_TOKEN_LOCATION_HEADER;
+    }
+}

--- a/tests/clients/TwitterOAuth2Test.php
+++ b/tests/clients/TwitterOAuth2Test.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace yiiunit\extensions\authclient\clients;
+
+use yii\authclient\clients\TwitterOAuth2;
+use yii\authclient\OAuth2;
+use yiiunit\extensions\authclient\clients\base\BaseOauth2ClientTestCase;
+
+class TwitterOAuth2Test extends BaseOauth2ClientTestCase
+{
+    protected function createClient()
+    {
+        return new TwitterOAuth2();
+    }
+
+    protected function getExpectedTokenLocation()
+    {
+        return OAuth2::ACCESS_TOKEN_LOCATION_HEADER;
+    }
+}

--- a/tests/clients/VKontakteTest.php
+++ b/tests/clients/VKontakteTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace yiiunit\extensions\authclient\clients;
+
+use yii\authclient\clients\VKontakte;
+use yii\authclient\OAuth2;
+use yiiunit\extensions\authclient\clients\base\BaseOauth2ClientTestCase;
+
+class VKontakteTest extends BaseOauth2ClientTestCase
+{
+    protected function createClient()
+    {
+        return new VKontakte();
+    }
+
+    protected function getExpectedTokenLocation()
+    {
+        return OAuth2::ACCESS_TOKEN_LOCATION_BODY;
+    }
+}

--- a/tests/clients/YandexTest.php
+++ b/tests/clients/YandexTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace yiiunit\extensions\authclient\clients;
+
+use yii\authclient\clients\Yandex;
+use yii\authclient\OAuth2;
+use yiiunit\extensions\authclient\clients\base\BaseOauth2ClientTestCase;
+
+class YandexTest extends BaseOauth2ClientTestCase
+{
+    protected function createClient()
+    {
+        return new Yandex();
+    }
+
+    protected function getExpectedTokenLocation()
+    {
+        return OAuth2::ACCESS_TOKEN_LOCATION_BODY;
+    }
+
+    protected function getAccessTokenBodyParamName()
+    {
+        return 'oauth_token';
+    }
+}

--- a/tests/clients/base/BaseOauth2ClientTestCase.php
+++ b/tests/clients/base/BaseOauth2ClientTestCase.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace yiiunit\extensions\authclient\clients\base;
+
+use yii\authclient\OAuth2;
+use yii\authclient\OAuthToken;
+use yii\base\InvalidConfigException;
+use yiiunit\extensions\authclient\TestCase;
+
+abstract class BaseOauth2ClientTestCase extends TestCase
+{
+    /**
+     * @return OAuth2
+     */
+    abstract protected function createClient();
+
+    /**
+     * @return string
+     */
+    abstract protected function getExpectedTokenLocation();
+
+    /**
+     * @return string
+     * @see https://datatracker.ietf.org/doc/html/rfc6750#section-6.1.1
+     */
+    protected function getAccessTokenHeaderTypeName()
+    {
+        return 'Bearer';
+    }
+
+    protected function getAccessTokenBodyParamName()
+    {
+        return 'access_token';
+    }
+
+    protected function setUp()
+    {
+        $config = [
+            'components' => [
+                'request' => [
+                    'hostInfo' => 'http://testdomain.com',
+                    'scriptUrl' => '/index.php',
+                ],
+            ],
+        ];
+        $this->mockApplication($config, '\yii\web\Application');
+    }
+
+    public function testTokenLocation()
+    {
+        $tokenLocation = $this->getExpectedTokenLocation();
+        $client = $this->createClient();
+        $testToken = 'test-token';
+        $client->setAccessToken(new OAuthToken(['token' => $testToken]));
+        $request = $client->createApiRequest();
+        $request->beforeSend(); // injects the access token
+
+        if ($tokenLocation == OAuth2::ACCESS_TOKEN_LOCATION_HEADER) {
+            $authorizationHeader = $request->getHeaders()->get('authorization');
+            $this->assertEquals($this->getAccessTokenHeaderTypeName() . ' ' . $testToken, $authorizationHeader);
+        } elseif ($tokenLocation == OAuth2::ACCESS_TOKEN_LOCATION_BODY) {
+            $accessTokenBodyParamName = $this->getAccessTokenBodyParamName();
+            $data = $request->getData();
+            $this->assertArrayHasKey($accessTokenBodyParamName, $data);
+            $this->assertEquals($testToken, $data[$accessTokenBodyParamName]);
+        } else {
+            throw new InvalidConfigException('Unknown token location "' . $tokenLocation . '".');
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #386

This PR adds support for easy configuration of the location of the access token in API requests for Oauth 2 clients.
It also adds a "plain" oauth 2 client that uses the access token in the header by default as specified in [RFC6749#section-7](https://datatracker.ietf.org/doc/html/rfc6749#section-7).