### PR TITLE
Fix #392: Now using array as default value for `token_endpoint_auth_methods_supported` in `OpenIdConnect::applyClientCredentialsToRequest()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 authclient extension Change Log
 2.2.17 under development
 ------------------------
 
-- no changes in this release.
+- Bug #392: Now using array as default value for `token_endpoint_auth_methods_supported` in `OpenIdConnect::applyClientCredentialsToRequest()` (strtob, rhertogh)
 
 
 2.2.16 May 10, 2024

--- a/src/OpenIdConnect.php
+++ b/src/OpenIdConnect.php
@@ -365,7 +365,7 @@ class OpenIdConnect extends OAuth2
      */
     protected function applyClientCredentialsToRequest($request)
     {
-        $supportedAuthMethods = $this->getConfigParam('token_endpoint_auth_methods_supported', 'client_secret_basic');
+        $supportedAuthMethods = $this->getConfigParam('token_endpoint_auth_methods_supported', ['client_secret_basic']);
 
         if (in_array('client_secret_basic', $supportedAuthMethods)) {
             $request->addHeaders([
@@ -400,7 +400,7 @@ class OpenIdConnect extends OAuth2
                 'assertion' => $assertion,
             ]);
         } else {
-            throw new InvalidConfigException('Unable to authenticate request: none of following auth methods is suported: ' . implode(', ', $supportedAuthMethods));
+            throw new InvalidConfigException('Unable to authenticate request: none of following auth methods is supported: ' . implode(', ', $supportedAuthMethods));
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #391

Using array as default value for `token_endpoint_auth_methods_supported` in `\yii\authclient\OpenIdConnect::applyClientCredentialsToRequest()`