### PR TITLE
Fix type for BaseOAuth property - accessToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 authclient extension Change Log
 2.2.18 under development
 ------------------------
 
-- Bug #393: Fix type for BaseOAuth property - accessToken (max-s-lab)
+- Bug #393: Fix type for `BaseOAuth` property - `accessToken` (max-s-lab)
 
 
 2.2.17 February 13, 2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Yii Framework 2 authclient extension Change Log
 2.2.18 under development
 ------------------------
 
-- no changes in this release.
+- Bug #393: Fix type for BaseOAuth property - accessToken (max-s-lab)
 
 
 2.2.17 February 13, 2025

--- a/src/BaseOAuth.php
+++ b/src/BaseOAuth.php
@@ -18,7 +18,7 @@ use yii\httpclient\Request;
  *
  * @see https://oauth.net/
  *
- * @property OAuthToken $accessToken Auth token instance. Note that the type of this property differs in
+ * @property OAuthToken|null $accessToken Auth token instance. Note that the type of this property differs in
  * getter and setter. See [[getAccessToken()]] and [[setAccessToken()]] for details.
  * @property string $returnUrl Return URL.
  * @property signature\BaseMethod $signatureMethod Signature method instance. Note that the type of this
@@ -110,7 +110,7 @@ abstract class BaseOAuth extends BaseClient
     }
 
     /**
-     * @return OAuthToken auth token instance.
+     * @return OAuthToken|null auth token instance.
      */
     public function getAccessToken()
     {
@@ -284,13 +284,13 @@ abstract class BaseOAuth extends BaseClient
 
     /**
      * Restores access token.
-     * @return OAuthToken auth token.
+     * @return OAuthToken|null auth token.
      */
     protected function restoreAccessToken()
     {
         $token = $this->getState('token');
         if (is_object($token)) {
-            /* @var $token OAuthToken */
+            /** @var OAuthToken $token */
             if ($token->getIsExpired() && $this->autoRefreshAccessToken) {
                 $token = $this->refreshAccessToken($token);
             }

--- a/src/BaseOAuth.php
+++ b/src/BaseOAuth.php
@@ -18,7 +18,7 @@ use yii\httpclient\Request;
  *
  * @see https://oauth.net/
  *
- * @property OAuthToken|null $accessToken Auth token instance. Note that the type of this property differs in
+ * @property OAuthToken|null $accessToken Auth token instance or null. Note that the type of this property differs in
  * getter and setter. See [[getAccessToken()]] and [[setAccessToken()]] for details.
  * @property string $returnUrl Return URL.
  * @property signature\BaseMethod $signatureMethod Signature method instance. Note that the type of this

--- a/src/OpenIdConnect.php
+++ b/src/OpenIdConnect.php
@@ -342,7 +342,9 @@ class OpenIdConnect extends OAuth2
             }
         } else {
             $accessToken = $this->accessToken;
-            $idToken = $accessToken->getParam('id_token');
+            if ($accessToken !== null) {
+                $idToken = $accessToken->getParam('id_token');
+            }
         }
 
         $idTokenData = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | <!-- comma-separated list of tickets # fixed by the PR, if any -->

The access token can be null, but only OAuthToken is specified in the type. Such a situation can definitely happen and it is even checked by tests.

![image](https://github.com/user-attachments/assets/98474e13-76d1-43c0-8a22-f4e76d63308e)

In my project, I bypassed this, but I would like to fix the type in the source code.
![image](https://github.com/user-attachments/assets/ca583156-2ef0-4b71-9933-7efd33644785)

