### PR TITLE
Fix Issue #401: Explicit null in InvalidResponseException constructor

### DIFF
--- a/src/InvalidResponseException.php
+++ b/src/InvalidResponseException.php
@@ -32,7 +32,7 @@ class InvalidResponseException extends Exception
      * @param int $code error code
      * @param \Exception $previous The previous exception used for the exception chaining.
      */
-    public function __construct($response, $message = null, $code = 0, \Exception $previous = null)
+    public function __construct($response, $message = null, $code = 0, ?\Exception $previous = null)
     {
         $this->response = $response;
         parent::__construct($message, $code, $previous);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #401
