### PR TITLE
Fix #405: Fixed OpenID Connect Client cache key by including the issuerUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Yii Framework 2 authclient extension Change Log
 - Enh #403: Applying Yii2 coding standards (@s1lver)
 - Enh #403: Raise min version to PHP 7.4 (@s1lver)
 - Bug #401: Explicit null in `InvalidResponseException` constructor (@cyansoftdev)
+- Bug #405: Fixed OpenID Connect Client cache key by including the issuerUrl (rhertogh)
+
 
 2.2.17 February 13, 2025
 ------------------------

--- a/src/OpenIdConnect.php
+++ b/src/OpenIdConnect.php
@@ -127,7 +127,7 @@ class OpenIdConnect extends OAuth2
     ];
     /**
      * @var string the prefix for the key used to store [[configParams]] data in cache.
-     * Actual cache key will be formed addition [[id]] value to it.
+     * Actual cache key will be formed with the [[id]] and [[issuerUrl]] values appended to it.
      * @see cache
      */
     public $configParamsCacheKeyPrefix = 'config-params-';
@@ -219,7 +219,7 @@ class OpenIdConnect extends OAuth2
     {
         if ($this->_configParams === null) {
             $cache = $this->getCache();
-            $cacheKey = $this->configParamsCacheKeyPrefix . $this->getId();
+            $cacheKey = $this->configParamsCacheKeyPrefix . $this->getId() . '_' . $this->issuerUrl;
             if ($cache === null || ($configParams = $cache->get($cacheKey)) === false) {
                 $configParams = $this->discoverConfig();
 
@@ -443,7 +443,7 @@ class OpenIdConnect extends OAuth2
     {
         if ($this->_jwkSet === null) {
             $cache = $this->getCache();
-            $cacheKey = $this->configParamsCacheKeyPrefix . '_jwkSet';
+            $cacheKey = $this->configParamsCacheKeyPrefix . $this->getId() . '_' . $this->issuerUrl .  '_jwkSet';
             if ($cache === null || ($jwkSet = $cache->get($cacheKey)) === false) {
                 $request = $this->createRequest()
                     ->setMethod('GET')

--- a/src/OpenIdConnect.php
+++ b/src/OpenIdConnect.php
@@ -443,7 +443,7 @@ class OpenIdConnect extends OAuth2
     {
         if ($this->_jwkSet === null) {
             $cache = $this->getCache();
-            $cacheKey = $this->configParamsCacheKeyPrefix . $this->getId() . '_' . $this->issuerUrl .  '_jwkSet';
+            $cacheKey = $this->configParamsCacheKeyPrefix . $this->getId() . '_' . $this->issuerUrl . '_jwkSet';
             if ($cache === null || ($jwkSet = $cache->get($cacheKey)) === false) {
                 $request = $this->createRequest()
                     ->setMethod('GET')

--- a/tests/OpenIdConnectTest.php
+++ b/tests/OpenIdConnectTest.php
@@ -54,7 +54,7 @@ class OpenIdConnectTest extends TestCase
         $cachedConfigParams = $authClient->getConfigParams();
 
         $authClient = new OpenIdConnect([
-            'issuerUrl' => 'https://login.microsoftonline.com/common/.well-known/openid-configuration',
+            'issuerUrl' => 'https://login.microsoftonline.com/common/',
             'id' => 'test',
             'cache' => $cache,
         ]);

--- a/tests/OpenIdConnectTest.php
+++ b/tests/OpenIdConnectTest.php
@@ -47,14 +47,22 @@ class OpenIdConnectTest extends TestCase
 
         $authClient = new OpenIdConnect([
             'issuerUrl' => 'https://accounts.google.com',
-            'id' => 'google',
+            'id' => 'test',
             'cache' => $cache,
         ]);
+        $this->assertEquals('https://accounts.google.com', $authClient->getConfigParam('issuer'));
         $cachedConfigParams = $authClient->getConfigParams();
 
         $authClient = new OpenIdConnect([
-            'issuerUrl' => 'https://invalid-url.com',
-            'id' => 'google',
+            'issuerUrl' => 'https://login.microsoftonline.com/common/.well-known/openid-configuration',
+            'id' => 'test',
+            'cache' => $cache,
+        ]);
+        $this->assertEquals('https://sts.windows.net/{tenantid}/', $authClient->getConfigParam('issuer'));
+
+        $authClient = new OpenIdConnect([
+            'issuerUrl' => 'https://accounts.google.com',
+            'id' => 'test',
             'cache' => $cache,
         ]);
         $this->assertEquals($cachedConfigParams, $authClient->getConfigParams());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | -

Currently the generation of the cache key for the OpenID Connect Client only includes the `getId()` as unique identifier. This gives problems in case the issuerUrl changes or if the client object is generated dynamically (in which case the id defaults to the class name).

In order to ensure the cache key differs for different issuers, the `issuerUrl` should be included in the cache key.