### PR TITLE
Force https scheme for return URL and remove 'xoauth_displayname' in …

### DIFF
--- a/src/BaseOAuth.php
+++ b/src/BaseOAuth.php
@@ -180,7 +180,8 @@ abstract class BaseOAuth extends BaseClient
 
         $params[0] = Yii::$app->controller->getRoute();
 
-        return Yii::$app->getUrlManager()->createAbsoluteUrl($params);
+        // Force https scheme for return URL in case running server in docker container, which is via http scheme from outside of container.
+        return Yii::$app->getUrlManager()->createAbsoluteUrl($params, 'https');
     }
 
     /**

--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -105,7 +105,6 @@ abstract class OAuth2 extends BaseOAuth
             'client_id' => $this->clientId,
             'response_type' => 'code',
             'redirect_uri' => $this->getReturnUrl(),
-            'xoauth_displayname' => Yii::$app->name,
         ];
         if (!empty($this->scope)) {
             $defaultParams['scope'] = $this->scope;


### PR DESCRIPTION
1. Force https scheme for return URL in case running server in docker container, which is via http scheme from docker host
2. Remove xoauth_displayname in OAuth2 in case $app->name contain non-alphanumeric characters which google will return '500 Internal Server Error'

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth redirect URL now enforces HTTPS protocol
  * Removed display name parameter from OAuth authorization flow

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yiisoft/yii2-authclient/pull/407?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->