### PR TITLE
Add explicit nullable type to `OAuthToken` parameters in `OAuth1` and `Facebook` clients to avoid PHP `8.4` implicit nullable types deprecation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Yii Framework 2 authclient extension Change Log
 - Enh #403: Raise min version to PHP 7.4 (@s1lver)
 - Bug #401: Explicit null in `InvalidResponseException` constructor (@cyansoftdev)
 - Bug #405: Fixed OpenID Connect Client cache key by including the issuerUrl (rhertogh)
+- Bug #406: Add explicit nullable type to `OAuthToken` parameters in `OAuth1` and `Facebook` clients to avoid PHP `8.4` implicit nullable types deprecation (@terabytesoftw)
 
 
 2.2.17 February 13, 2025

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": ">=7.4",
-        "yiisoft/yii2": "~2.0.54",
+        "yiisoft/yii2": "~2.0.55",
         "yiisoft/yii2-httpclient": "~2.0.5",
         "paragonie/random_compat": ">=1"
     },
@@ -60,5 +60,11 @@
         "allow-plugins": {
             "yiisoft/yii2-composer": true
         }
+    },
+    "scripts": {
+        "cs": "./vendor/bin/phpcs",
+        "cs-fix": "./vendor/bin/phpcbf",
+        "static": "./vendor/bin/phpstan --memory-limit=-1",
+        "tests": "./vendor/bin/phpunit"
     }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -3,7 +3,7 @@
     <rule ref="vendor/yiisoft/yii2-coding-standards/Yii2"></rule>
 
     <!-- generate relative paths -->
-    <arg name="basepath" value="src"/>
+    <arg name="basepath" value="."/>
 
     <rule ref="Squiz.NamingConventions.ValidVariableName.PrivateNoUnderscore">
         <exclude-pattern>/OpenIdConnect\.php$</exclude-pattern>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -8,4 +8,8 @@
     <rule ref="Squiz.NamingConventions.ValidVariableName.PrivateNoUnderscore">
         <exclude-pattern>/OpenIdConnect\.php$</exclude-pattern>
     </rule>
+
+    <!-- directories to check -->
+    <file>src</file>
+    <file>tests</file>
 </ruleset>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -43,14 +43,32 @@ parameters:
 			path: src/AuthAction.php
 
 		-
+			message: '#^Cannot call method get\(\) on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/AuthAction.php
+
+		-
+			message: '#^Cannot call method getRequest\(\) on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: method.nonObject
+			count: 4
+			path: src/AuthAction.php
+
+		-
+			message: '#^Cannot call method getResponse\(\) on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: method.nonObject
+			count: 4
+			path: src/AuthAction.php
+
+		-
 			message: '#^Cannot call method getReturnUrl\(\) on array\|string\|yii\\web\\User\.$#'
 			identifier: method.nonObject
 			count: 1
 			path: src/AuthAction.php
 
 		-
-			message: '#^Class yii\\authclient\\AuthAction extends generic class yii\\base\\Action but does not specify its types\: T$#'
-			identifier: missingType.generics
+			message: '#^Cannot call method getView\(\) on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/AuthAction.php
 
@@ -111,12 +129,6 @@ parameters:
 		-
 			message: '#^Property yii\\authclient\\AuthAction\:\:\$user type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: src/AuthAction.php
-
-		-
-			message: '#^Property yii\\authclient\\AuthAction\:\:\$user with generic class yii\\web\\User does not specify its types\: T$#'
-			identifier: missingType.generics
 			count: 1
 			path: src/AuthAction.php
 
@@ -385,7 +397,31 @@ parameters:
 			path: src/BaseOAuth.php
 
 		-
-			message: '#^Cannot call method getRoute\(\) on yii\\console\\Controller\<yii\\base\\Module\>\|yii\\web\\Controller\<yii\\base\\Module\>\|null\.$#'
+			message: '#^Cannot access property \$controller on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/BaseOAuth.php
+
+		-
+			message: '#^Cannot access property \$name on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/BaseOAuth.php
+
+		-
+			message: '#^Cannot call method getRequest\(\) on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/BaseOAuth.php
+
+		-
+			message: '#^Cannot call method getRoute\(\) on yii\\console\\Controller\|yii\\web\\Controller\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/BaseOAuth.php
+
+		-
+			message: '#^Cannot call method getUrlManager\(\) on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
 			identifier: method.nonObject
 			count: 1
 			path: src/BaseOAuth.php
@@ -565,6 +601,18 @@ parameters:
 			path: src/CacheStateStorage.php
 
 		-
+			message: '#^Cannot call method get\(\) on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/CacheStateStorage.php
+
+		-
+			message: '#^Cannot call method has\(\) on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/CacheStateStorage.php
+
+		-
 			message: '#^Cannot call method set\(\) on array\|string\|yii\\caching\\Cache\.$#'
 			identifier: method.nonObject
 			count: 1
@@ -697,6 +745,18 @@ parameters:
 			path: src/OAuth1.php
 
 		-
+			message: '#^Cannot call method getRequest\(\) on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/OAuth1.php
+
+		-
+			message: '#^Cannot call method getSecurity\(\) on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/OAuth1.php
+
+		-
 			message: '#^Method yii\\authclient\\OAuth1\:\:applyAccessTokenToRequest\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -775,12 +835,6 @@ parameters:
 			path: src/OAuth1.php
 
 		-
-			message: '#^Access to an undefined property yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\:\:\$session\.$#'
-			identifier: property.notFound
-			count: 1
-			path: src/OAuth2.php
-
-		-
 			message: '#^Call to an undefined method yii\\console\\Request\|yii\\web\\Request\:\:get\(\)\.$#'
 			identifier: method.notFound
 			count: 1
@@ -789,6 +843,42 @@ parameters:
 		-
 			message: '#^Call to an undefined method yii\\console\\Request\|yii\\web\\Request\:\:post\(\)\.$#'
 			identifier: method.notFound
+			count: 1
+			path: src/OAuth2.php
+
+		-
+			message: '#^Cannot access property \$name on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/OAuth2.php
+
+		-
+			message: '#^Cannot access property \$security on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/OAuth2.php
+
+		-
+			message: '#^Cannot access property \$session on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/OAuth2.php
+
+		-
+			message: '#^Cannot call method getRequest\(\) on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/OAuth2.php
+
+		-
+			message: '#^Cannot call method getSecurity\(\) on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/OAuth2.php
+
+		-
+			message: '#^Cannot call method has\(\) on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/OAuth2.php
 
@@ -973,6 +1063,30 @@ parameters:
 			path: src/OpenId.php
 
 		-
+			message: '#^Cannot access property \$name on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/OpenId.php
+
+		-
+			message: '#^Cannot access property \$requestedRoute on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/OpenId.php
+
+		-
+			message: '#^Cannot call method getRequest\(\) on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: method.nonObject
+			count: 3
+			path: src/OpenId.php
+
+		-
+			message: '#^Cannot call method getUrlManager\(\) on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/OpenId.php
+
+		-
 			message: '#^If condition is always true\.$#'
 			identifier: if.alwaysTrue
 			count: 1
@@ -1141,6 +1255,12 @@ parameters:
 			path: src/OpenId.php
 
 		-
+			message: '#^Parameter \#2 \.\.\.\$args of function array_merge expects array, array\|object given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/OpenId.php
+
+		-
 			message: '#^Property yii\\authclient\\OpenId\:\:\$_trustRoot \(string\) does not accept string\|null\.$#'
 			identifier: assign.propertyType
 			count: 1
@@ -1203,6 +1323,18 @@ parameters:
 		-
 			message: '#^Call to static method createFromValues\(\) on an unknown class Jose\\Component\\KeyManagement\\JWKFactory\.$#'
 			identifier: class.notFound
+			count: 1
+			path: src/OpenIdConnect.php
+
+		-
+			message: '#^Cannot access property \$security on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/OpenIdConnect.php
+
+		-
+			message: '#^Cannot call method getSecurity\(\) on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/OpenIdConnect.php
 
@@ -1406,6 +1538,18 @@ parameters:
 
 		-
 			message: '#^Cannot call method get\(\) on array\|string\|yii\\web\\Session\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/SessionStateStorage.php
+
+		-
+			message: '#^Cannot call method get\(\) on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/SessionStateStorage.php
+
+		-
+			message: '#^Cannot call method has\(\) on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
 			identifier: method.nonObject
 			count: 1
 			path: src/SessionStateStorage.php
@@ -1699,6 +1843,12 @@ parameters:
 			path: src/signature/RsaSha.php
 
 		-
+			message: '#^Cannot access property \$name on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: property.nonObject
+			count: 2
+			path: src/views/redirect.php
+
+		-
 			message: '#^Call to an undefined method yii\\base\\View\:\:registerJs\(\)\.$#'
 			identifier: method.notFound
 			count: 1
@@ -1717,7 +1867,31 @@ parameters:
 			path: src/widgets/AuthChoice.php
 
 		-
-			message: '#^Cannot call method getRoute\(\) on yii\\console\\Controller\<yii\\base\\Module\>\|yii\\web\\Controller\<yii\\base\\Module\>\|null\.$#'
+			message: '#^Cannot access property \$controller on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/widgets/AuthChoice.php
+
+		-
+			message: '#^Cannot call method get\(\) on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/widgets/AuthChoice.php
+
+		-
+			message: '#^Cannot call method getRequest\(\) on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/widgets/AuthChoice.php
+
+		-
+			message: '#^Cannot call method getRoute\(\) on yii\\console\\Controller\|yii\\web\\Controller\|null\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/widgets/AuthChoice.php
+
+		-
+			message: '#^Cannot call method getView\(\) on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
 			identifier: method.nonObject
 			count: 1
 			path: src/widgets/AuthChoice.php
@@ -2181,12 +2355,6 @@ parameters:
 		-
 			message: '#^Property yiiunit\\extensions\\authclient\\TestCase\:\:\$params has no type specified\.$#'
 			identifier: missingType.property
-			count: 1
-			path: tests/TestCase.php
-
-		-
-			message: '#^Static property yii\\BaseYii\<yii\\web\\IdentityInterface\>\:\:\$app \(yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\) does not accept null\.$#'
-			identifier: assign.propertyType
 			count: 1
 			path: tests/TestCase.php
 

--- a/src/OAuth1.php
+++ b/src/OAuth1.php
@@ -113,12 +113,12 @@ abstract class OAuth1 extends BaseOAuth
 
     /**
      * Composes user authorization URL.
-     * @param OAuthToken $requestToken OAuth request token.
+     * @param OAuthToken|null $requestToken OAuth request token.
      * @param array $params additional request params.
      * @return string authorize URL
      * @throws InvalidParamException on failure.
      */
-    public function buildAuthUrl(OAuthToken $requestToken = null, array $params = [])
+    public function buildAuthUrl(?OAuthToken $requestToken = null, array $params = [])
     {
         if (!is_object($requestToken)) {
             $requestToken = $this->getState('requestToken');
@@ -134,14 +134,14 @@ abstract class OAuth1 extends BaseOAuth
     /**
      * Fetches OAuth access token.
      * @param string $oauthToken OAuth token returned with redirection back to client.
-     * @param OAuthToken $requestToken OAuth request token.
+     * @param OAuthToken|null $requestToken OAuth request token.
      * @param string $oauthVerifier OAuth verifier.
      * @param array $params additional request params.
      * @return OAuthToken OAuth access token.
      * @throws InvalidParamException on failure.
      * @throws HttpException in case oauth token miss-matches request token.
      */
-    public function fetchAccessToken($oauthToken = null, OAuthToken $requestToken = null, $oauthVerifier = null, array $params = [])
+    public function fetchAccessToken($oauthToken = null, ?OAuthToken $requestToken = null, $oauthVerifier = null, array $params = [])
     {
         $incomingRequest = Yii::$app->getRequest();
 

--- a/src/clients/Facebook.php
+++ b/src/clients/Facebook.php
@@ -195,7 +195,7 @@ class Facebook extends OAuth2
      * @return string client auth code.
      * @since 2.1.3
      */
-    public function fetchClientAuthCode(OAuthToken $token = null, $params = [])
+    public function fetchClientAuthCode(?OAuthToken $token = null, $params = [])
     {
         if ($token === null) {
             $token = $this->getAccessToken();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PHP 8.4 deprecation warnings by explicitly allowing nullable OAuth token parameters in authentication flows.

* **Chores**
  * Bumped framework dependency to 2.0.55.
  * Added composer scripts for code style, static analysis, and tests.
  * Updated static analysis baseline and coding-standard configuration to scan source and tests.

* **Documentation**
  * Updated changelog with the new entry.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yiisoft/yii2-authclient/pull/408?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->