### PR TITLE
Cast nullable secrets to string before `hash_hmac()` and `rawurlencode()` in `Facebook` and `OAuth1` clients to avoid PHP `8.5` deprecations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Yii Framework 2 authclient extension Change Log
 - Bug #401: Explicit null in `InvalidResponseException` constructor (@cyansoftdev)
 - Bug #405: Fixed OpenID Connect Client cache key by including the issuerUrl (rhertogh)
 - Bug #406: Add explicit nullable type to `OAuthToken` parameters in `OAuth1` and `Facebook` clients to avoid PHP `8.4` implicit nullable types deprecation (@terabytesoftw)
+- Bug #407: Cast nullable secrets to string before `hash_hmac()` and `rawurlencode()` in `Facebook` and `OAuth1` clients to avoid PHP `8.5` deprecations (@terabytesoftw)
 
 
 2.2.17 February 13, 2025

--- a/src/OAuth1.php
+++ b/src/OAuth1.php
@@ -361,14 +361,14 @@ abstract class OAuth1 extends BaseOAuth
     protected function composeSignatureKey($token = null)
     {
         $signatureKeyParts = [
-            $this->consumerSecret
+            (string) $this->consumerSecret
         ];
 
         if ($token === null) {
             $token = $this->getAccessToken();
         }
         if (is_object($token)) {
-            $signatureKeyParts[] = $token->getTokenSecret();
+            $signatureKeyParts[] = (string) $token->getTokenSecret();
         } else {
             $signatureKeyParts[] = '';
         }

--- a/src/clients/Facebook.php
+++ b/src/clients/Facebook.php
@@ -110,7 +110,7 @@ class Facebook extends OAuth2
         if (($machineId = $accessToken->getParam('machine_id')) !== null) {
             $data['machine_id'] = $machineId;
         }
-        $data['appsecret_proof'] = hash_hmac('sha256', $accessToken->getToken(), $this->clientSecret);
+        $data['appsecret_proof'] = hash_hmac('sha256', $accessToken->getToken(), (string) $this->clientSecret);
         $request->setData($data);
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -97,9 +97,12 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     {
         $classReflection = new \ReflectionClass(get_class($object));
         $methodReflection = $classReflection->getMethod($method);
-        $methodReflection->setAccessible(true);
-        $result = $methodReflection->invokeArgs($object, $args);
-        $methodReflection->setAccessible(false);
-        return $result;
+
+        // ReflectionMethod::setAccessible() is required on PHP < 8.1 but is a no-op since 8.1 and deprecated since 8.5.
+        if (PHP_VERSION_ID < 80100) {
+            $methodReflection->setAccessible(true);
+        }
+
+        return $methodReflection->invokeArgs($object, $args);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed PHP 8.5 deprecation warnings by ensuring client secrets are properly cast to strings in OAuth authentication operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yiisoft/yii2-authclient/pull/409?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->