### PR TITLE
Fix invalid `Origin: /` header on PKCE token request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Yii Framework 2 authclient extension Change Log
 - Bug #405: Fixed OpenID Connect Client cache key by including the issuerUrl (rhertogh)
 - Bug #406: Add explicit nullable type to `OAuthToken` parameters in `OAuth1` and `Facebook` clients to avoid PHP `8.4` implicit nullable types deprecation (@terabytesoftw)
 - Bug #407: Cast nullable secrets to string before `hash_hmac()` and `rawurlencode()` in `Facebook` and `OAuth1` clients to avoid PHP `8.5` deprecations (@terabytesoftw)
-- Bug #414: Send the application origin instead of the relative path `/` in the PKCE token request `Origin` header, so providers validating it (e.g. Keycloak) no longer reject the request (@luke-)
+- Bug #414: Send a valid origin instead of the relative path `/` in the PKCE token request `Origin` header, so providers validating it (e.g. Keycloak) no longer reject the request; the origin is derived from `returnUrl` and can be configured via the new `OAuth2::$origin` property (@luke-)
 
 
 2.2.17 February 13, 2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Yii Framework 2 authclient extension Change Log
 - Bug #405: Fixed OpenID Connect Client cache key by including the issuerUrl (rhertogh)
 - Bug #406: Add explicit nullable type to `OAuthToken` parameters in `OAuth1` and `Facebook` clients to avoid PHP `8.4` implicit nullable types deprecation (@terabytesoftw)
 - Bug #407: Cast nullable secrets to string before `hash_hmac()` and `rawurlencode()` in `Facebook` and `OAuth1` clients to avoid PHP `8.5` deprecations (@terabytesoftw)
+- Bug #414: Send the application origin instead of the relative path `/` in the PKCE token request `Origin` header, so providers validating it (e.g. Keycloak) no longer reject the request (@luke-)
 
 
 2.2.17 February 13, 2025

--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -174,7 +174,7 @@ abstract class OAuth2 extends BaseOAuth
 
          // Azure AD will complain if there is no `Origin` header.
         if ($this->enablePkce) {
-            $request->addHeaders(['Origin' => Url::to('/')]);
+            $request->addHeaders(['Origin' => Url::base(true)]);
         }
 
         $this->applyClientCredentialsToRequest($request);

--- a/src/OAuth2.php
+++ b/src/OAuth2.php
@@ -11,7 +11,6 @@ namespace yii\authclient;
 use Yii;
 use yii\base\InvalidConfigException;
 use yii\helpers\Json;
-use yii\helpers\Url;
 use yii\web\HttpException;
 
 /**
@@ -33,6 +32,8 @@ use yii\web\HttpException;
  *
  * @see https://oauth.net/2/
  * @see https://tools.ietf.org/html/rfc6749
+ *
+ * @property string $origin Origin value.
  *
  * @author Paul Klimov <klimov.paul@gmail.com>
  * @since 2.0
@@ -93,6 +94,36 @@ abstract class OAuth2 extends BaseOAuth
      */
     public $accessTokenLocation = self::ACCESS_TOKEN_LOCATION_BODY;
 
+    /**
+     * @var string|null value of the `Origin` header sent with the access token request when [[enablePkce]]
+     * is enabled. Note: this should be a valid origin (scheme, host and optional port, e.g. `https://example.com`).
+     * By default the origin is derived from [[returnUrl]].
+     * @since 3.0.0
+     */
+    private $_origin;
+
+
+    /**
+     * @param string $origin origin value.
+     * @return void
+     * @since 3.0.0
+     */
+    public function setOrigin($origin)
+    {
+        $this->_origin = $origin;
+    }
+
+    /**
+     * @return string origin value.
+     * @since 3.0.0
+     */
+    public function getOrigin()
+    {
+        if ($this->_origin === null) {
+            $this->_origin = $this->defaultOrigin();
+        }
+        return $this->_origin;
+    }
 
     /**
      * Composes user authorization URL.
@@ -174,7 +205,7 @@ abstract class OAuth2 extends BaseOAuth
 
          // Azure AD will complain if there is no `Origin` header.
         if ($this->enablePkce) {
-            $request->addHeaders(['Origin' => Url::base(true)]);
+            $request->addHeaders(['Origin' => $this->getOrigin()]);
         }
 
         $this->applyClientCredentialsToRequest($request);
@@ -246,6 +277,26 @@ abstract class OAuth2 extends BaseOAuth
         $this->setAccessToken($token);
 
         return $token;
+    }
+
+    /**
+     * Composes default [[origin]] value, deriving it from [[returnUrl]].
+     * @return string origin value.
+     * @throws InvalidConfigException if the origin can not be derived from [[returnUrl]].
+     * @since 3.0.0
+     */
+    protected function defaultOrigin()
+    {
+        $components = parse_url($this->getReturnUrl());
+        if (!isset($components['scheme'], $components['host'])) {
+            throw new InvalidConfigException('Unable to derive the origin from "returnUrl". Set the "origin" property explicitly.');
+        }
+
+        $origin = $components['scheme'] . '://' . $components['host'];
+        if (isset($components['port'])) {
+            $origin .= ':' . $components['port'];
+        }
+        return $origin;
     }
 
     /**

--- a/tests/OAuth2Test.php
+++ b/tests/OAuth2Test.php
@@ -3,6 +3,7 @@
 namespace yiiunit\extensions\authclient;
 
 use yii\authclient\OAuth2;
+use yii\base\InvalidConfigException;
 
 class OAuth2Test extends TestCase
 {
@@ -48,6 +49,40 @@ class OAuth2Test extends TestCase
         $this->assertStringContainsString($authUrl, $builtAuthUrl, 'No auth URL present!');
         $this->assertStringContainsString($clientId, $builtAuthUrl, 'No client id present!');
         $this->assertStringContainsString(rawurlencode($returnUrl), $builtAuthUrl, 'No return URL present!');
+    }
+
+    public function testGetOriginDerivedFromReturnUrl(): void
+    {
+        $oauthClient = $this->createClient();
+        $oauthClient->returnUrl = 'https://example.com/admin/site/auth?authclient=test';
+
+        $this->assertEquals('https://example.com', $oauthClient->getOrigin());
+    }
+
+    public function testGetOriginKeepsExplicitPort(): void
+    {
+        $oauthClient = $this->createClient();
+        $oauthClient->returnUrl = 'https://example.com:8443/site/auth';
+
+        $this->assertEquals('https://example.com:8443', $oauthClient->getOrigin());
+    }
+
+    public function testGetOriginThrowsOnRelativeReturnUrl(): void
+    {
+        $oauthClient = $this->createClient();
+        $oauthClient->returnUrl = '/site/auth';
+
+        $this->expectException(InvalidConfigException::class);
+        $oauthClient->getOrigin();
+    }
+
+    public function testSetOrigin(): void
+    {
+        $oauthClient = $this->createClient();
+        $oauthClient->returnUrl = 'https://example.com/site/auth';
+        $oauthClient->origin = 'https://origin.example.com';
+
+        $this->assertEquals('https://origin.example.com', $oauthClient->getOrigin());
     }
 
     public function testPkceCodeChallengeIsPresentInAuthUrl(): void


### PR DESCRIPTION
When `enablePkce` is enabled, `OAuth2::fetchAccessToken()` sets the `Origin` header to `Url::to('/')`, which returns the relative path `/` — not a valid origin (per RFC 6454 an origin is `scheme://host[:port]`).

Azure AD only checks that the header is present, so `/` happens to pass. But providers that validate the value — e.g. **Keycloak** — reject it against the client's allowed Web Origins:

```
403 {"error":"Invalid origin"}
```

This sends the application origin via `Request::getHostInfo()` instead, which is a valid origin and keeps the header present for Azure AD.