### PR TITLE
Fix #417: Separate the `@property` annotations in case of different types in getters and setters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Yii Framework 2 authclient extension Change Log
 - Bug #405: Fixed OpenID Connect Client cache key by including the issuerUrl (rhertogh)
 - Bug #406: Add explicit nullable type to `OAuthToken` parameters in `OAuth1` and `Facebook` clients to avoid PHP `8.4` implicit nullable types deprecation (@terabytesoftw)
 - Bug #407: Cast nullable secrets to string before `hash_hmac()` and `rawurlencode()` in `Facebook` and `OAuth1` clients to avoid PHP `8.5` deprecations (@terabytesoftw)
+- Bug #417: Separate the `@property` annotations in case of different types in getters and setters (mspirkov)
 
 
 2.2.17 February 13, 2025

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -151,7 +151,25 @@ parameters:
 			path: src/AuthAction.php
 
 		-
+			message: '#^Class yii\\authclient\\BaseClient has PHPDoc tag @property for property \$httpClient with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/BaseClient.php
+
+		-
 			message: '#^Class yii\\authclient\\BaseClient has PHPDoc tag @property for property \$normalizeUserAttributeMap with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/BaseClient.php
+
+		-
+			message: '#^Class yii\\authclient\\BaseClient has PHPDoc tag @property for property \$requestOptions with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/BaseClient.php
+
+		-
+			message: '#^Class yii\\authclient\\BaseClient has PHPDoc tag @property for property \$stateStorage with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/BaseClient.php
@@ -164,12 +182,6 @@ parameters:
 
 		-
 			message: '#^Class yii\\authclient\\BaseClient has PHPDoc tag @property for property \$viewOptions with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/BaseClient.php
-
-		-
-			message: '#^Class yii\\authclient\\BaseClient has PHPDoc tag @property\-read for property \$requestOptions with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/BaseClient.php
@@ -427,6 +439,18 @@ parameters:
 			path: src/BaseOAuth.php
 
 		-
+			message: '#^Class yii\\authclient\\BaseOAuth has PHPDoc tag @property for property \$accessToken with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/BaseOAuth.php
+
+		-
+			message: '#^Class yii\\authclient\\BaseOAuth has PHPDoc tag @property for property \$signatureMethod with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/BaseOAuth.php
+
+		-
 			message: '#^Method yii\\authclient\\BaseOAuth\:\:api\(\) has parameter \$apiSubUrl with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -677,6 +701,12 @@ parameters:
 			identifier: missingType.return
 			count: 1
 			path: src/ClientInterface.php
+
+		-
+			message: '#^Class yii\\authclient\\Collection has PHPDoc tag @property for property \$clients with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Collection.php
 
 		-
 			message: '#^Method yii\\authclient\\Collection\:\:createClient\(\) has parameter \$config with no value type specified in iterable type array\.$#'
@@ -943,7 +973,7 @@ parameters:
 			path: src/OAuth2.php
 
 		-
-			message: '#^Class yii\\authclient\\OAuthToken has PHPDoc tag @property\-read for property \$params with no value type specified in iterable type array\.$#'
+			message: '#^Class yii\\authclient\\OAuthToken has PHPDoc tag @property for property \$params with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/OAuthToken.php
@@ -1335,6 +1365,12 @@ parameters:
 		-
 			message: '#^Cannot call method getSecurity\(\) on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
 			identifier: method.nonObject
+			count: 1
+			path: src/OpenIdConnect.php
+
+		-
+			message: '#^Class yii\\authclient\\OpenIdConnect has PHPDoc tag @property for property \$cache with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/OpenIdConnect.php
 
@@ -1897,7 +1933,7 @@ parameters:
 			path: src/widgets/AuthChoice.php
 
 		-
-			message: '#^Class yii\\authclient\\widgets\\AuthChoice has PHPDoc tag @property\-read for property \$baseAuthUrl with no value type specified in iterable type array\.$#'
+			message: '#^Class yii\\authclient\\widgets\\AuthChoice has PHPDoc tag @property for property \$baseAuthUrl with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/widgets/AuthChoice.php
@@ -1977,6 +2013,12 @@ parameters:
 		-
 			message: '#^Access to an undefined property yii\\authclient\\ClientInterface\:\:\$scope\.$#'
 			identifier: property.notFound
+			count: 1
+			path: src/widgets/GooglePlusButton.php
+
+		-
+			message: '#^Class yii\\authclient\\widgets\\GooglePlusButton has PHPDoc tag @property for property \$callback with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/widgets/GooglePlusButton.php
 

--- a/src/BaseClient.php
+++ b/src/BaseClient.php
@@ -21,14 +21,14 @@ use yii\httpclient\Client;
  *
  * @see ClientInterface
  *
- * @property Client $httpClient Internal HTTP client. Note that the type of this property differs in getter
- * and setter. See [[getHttpClient()]] and [[setHttpClient()]] for details.
+ * @property-read Client $httpClient Internal HTTP client.
+ * @property-write array|Client $httpClient Internal HTTP client.
  * @property string $id Service id.
  * @property string $name Service name.
  * @property array $normalizeUserAttributeMap Normalize user attribute map.
- * @property-read array $requestOptions HTTP request options.
- * @property StateStorageInterface $stateStorage Stage storage. Note that the type of this property differs in
- * getter and setter. See [[getStateStorage()]] and [[setStateStorage()]] for details.
+ * @property array $requestOptions HTTP request options.
+ * @property-read StateStorageInterface $stateStorage Stage storage.
+ * @property-write StateStorageInterface|array|string $stateStorage Stage storage to be used.
  * @property string $title Service title.
  * @property array $userAttributes List of user attributes.
  * @property array $viewOptions View options in format: optionName => optionValue.

--- a/src/BaseOAuth.php
+++ b/src/BaseOAuth.php
@@ -19,11 +19,13 @@ use yii\httpclient\Request;
  *
  * @see https://oauth.net/
  *
- * @property OAuthToken|null $accessToken Auth token instance or null. Note that the type of this property differs in
- * getter and setter. See [[getAccessToken()]] and [[setAccessToken()]] for details.
+ * @property-read OAuthToken|null $accessToken Auth token instance.
+ * @property-write array|OAuthToken|null $accessToken Access token or its configuration. Set to null to
+ * restore token from token store.
  * @property string $returnUrl Return URL.
- * @property signature\BaseMethod $signatureMethod Signature method instance. Note that the type of this
- * property differs in getter and setter. See [[getSignatureMethod()]] and [[setSignatureMethod()]] for details.
+ * @property-read signature\BaseMethod $signatureMethod Signature method instance.
+ * @property-write array|signature\BaseMethod $signatureMethod Signature method instance or its array
+ * configuration.
  *
  * @author Paul Klimov <klimov.paul@gmail.com>
  * @since 2.0

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -39,6 +39,7 @@ use Yii;
  * ```
  *
  * @property-read ClientInterface[] $clients List of auth clients.
+ * @property-write array $clients List of auth clients.
  *
  * @author Paul Klimov <klimov.paul@gmail.com>
  * @since 2.0

--- a/src/OAuthToken.php
+++ b/src/OAuthToken.php
@@ -14,12 +14,13 @@ use yii\helpers\ArrayHelper;
 /**
  * Token represents OAuth token.
  *
- * @property int $expireDuration Token expiration duration. Note that the type of this property differs in
- * getter and setter. See [[getExpireDuration()]] and [[setExpireDuration()]] for details.
+ * @property-read int $expireDuration Token expiration duration.
+ * @property-write string $expireDuration Token expiration duration.
  * @property string $expireDurationParamKey Expire duration param key.
  * @property-read bool $isExpired Is token expired.
  * @property-read bool $isValid Is token valid.
- * @property-read array $params
+ * @property array $params
+ * @property-write string $refreshToken
  * @property string $token Token value.
  * @property string $tokenSecret Token secret value.
  *

--- a/src/OpenIdConnect.php
+++ b/src/OpenIdConnect.php
@@ -66,8 +66,9 @@ use yii\web\HttpException;
  * @see https://openid.net/connect/
  * @see OAuth2
  *
- * @property Cache|null $cache The cache object, `null` - if not enabled. Note that the type of this property
- * differs in getter and setter. See [[getCache()]] and [[setCache()]] for details.
+ * @property-read Cache|null $cache The cache object, `null` - if not enabled.
+ * @property-write Cache|array|string|null $cache The cache object or the ID of the cache application
+ * component.
  * @property array $configParams OpenID provider configuration parameters.
  * @property bool $validateAuthNonce Whether to use and validate auth 'nonce' parameter in authentication
  * flow.

--- a/src/widgets/AuthChoice.php
+++ b/src/widgets/AuthChoice.php
@@ -58,8 +58,8 @@ use yii\authclient\ClientInterface;
  *
  * @see \yii\authclient\AuthAction
  *
- * @property-read array $baseAuthUrl Base auth URL configuration.
- * @property-read ClientInterface[] $clients Auth providers.
+ * @property array $baseAuthUrl Base auth URL configuration.
+ * @property ClientInterface[] $clients Auth providers.
  *
  * @author Paul Klimov <klimov.paul@gmail.com>
  * @since 2.0

--- a/src/widgets/GooglePlusButton.php
+++ b/src/widgets/GooglePlusButton.php
@@ -21,8 +21,8 @@ use yii\web\View;
  * @see GoogleHybrid
  * @see https://developers.google.com/+/web/signin/
  *
- * @property string $callback Callback JavaScript function name. Note that the type of this property differs
- * in getter and setter. See [[getCallback()]] and [[setCallback()]] for details.
+ * @property-read string $callback Callback JavaScript function name.
+ * @property-write string|array $callback Callback JavaScript function name or URL config.
  *
  * @author Paul Klimov <klimov.paul@gmail.com>
  * @since 2.0.4


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

See: https://github.com/yiisoft/yii2/pull/21042